### PR TITLE
메인 페이지 스타일 수정

### DIFF
--- a/src/components/home/banner/Banner.styled.ts
+++ b/src/components/home/banner/Banner.styled.ts
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
+  margin-top: 2rem;
+
   img {
     width: 100%;
   }

--- a/src/components/home/projectCardLists/cardList/CardList.styled.ts
+++ b/src/components/home/projectCardLists/cardList/CardList.styled.ts
@@ -6,15 +6,20 @@ export const Container = styled.div`
   height: 22rem;
   border: 1px solid ${({ theme }) => theme.color.border};
   border-radius: 2rem;
-  padding: 2rem 1rem;
+  padding: 1.8rem;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: 1rem;
 
+  .deadLine {
+    color: #3c3c3c;
+    font-size: 0.9rem;
+  }
+
   .title {
     height: 4rem;
-    font-size: 1.2rem;
+    font-size: 1.25rem;
     font-weight: bold;
     display: -webkit-box;
     -webkit-line-clamp: 2;
@@ -29,11 +34,21 @@ export const Container = styled.div`
     gap: 0.5rem;
   }
 
+  .positionTitle {
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: #5f5f5f;
+  }
+
   .skillTag,
   .positionTags {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+  }
+
+  .positionTags {
+    font-size: 0.8rem;
   }
 
   .info {
@@ -46,11 +61,17 @@ export const Container = styled.div`
       display: flex;
       align-items: center;
       gap: 0.5rem;
+
+      span {
+        font-size: 0.95rem;
+        font-weight: 500;
+        color: #646464;
+      }
     }
     .etc {
       display: flex;
       align-items: end;
-      gap: 1rem;
+      gap: 0.5rem;
       img {
         width: 2rem;
       }
@@ -60,10 +81,11 @@ export const Container = styled.div`
 
         svg {
           width: 1.3rem;
+          color: #5f5f5f;
         }
         span {
-          width: 2.5rem;
           flex-direction: row;
+          color: #5f5f5f;
         }
       }
     }

--- a/src/components/home/projectStats/ProjectStats.styled.ts
+++ b/src/components/home/projectStats/ProjectStats.styled.ts
@@ -1,13 +1,12 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  height: 22rem;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  padding: 8rem 0;
 `;
 export const Wrapper = styled.div`
   display: flex;
+  justify-content: center;
+  width: 100%;
   height: 7.25rem;
-  gap: 6.25rem;
 `;

--- a/src/components/home/projectStats/projectStat/ProjectStat.styled.ts
+++ b/src/components/home/projectStats/projectStat/ProjectStat.styled.ts
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  width: 18.75rem;
-  height: 7.25rem;
   display: flex;
+  justify-content: center;
+  flex: 1;
   padding-left: 1.25rem;
   align-items: center;
   gap: 1rem;

--- a/src/components/home/searchFiltering/SearchFiltering.styled.ts
+++ b/src/components/home/searchFiltering/SearchFiltering.styled.ts
@@ -6,6 +6,5 @@ export const Wrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: 8.5rem;
-  position: relative;
+  margin-bottom: 2rem;
 `;

--- a/src/components/home/searchFiltering/filteringContents/FilteringContents.styled.ts
+++ b/src/components/home/searchFiltering/filteringContents/FilteringContents.styled.ts
@@ -1,18 +1,19 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  width: 40vw;
+  width: 60vw;
   display: flex;
   gap: 1rem;
+  position: relative;
 
   > * {
     width: 7.7rem;
+    padding: 0.7rem 0;
     border: 1px solid ${({ theme }) => theme.color.border};
     display: flex;
     justify-content: space-between;
     align-items: center;
     border-radius: 1.5rem;
-    height: 2.8rem;
   }
 
   .filteringButton {
@@ -44,7 +45,7 @@ export const Container = styled.div`
     height: 100%;
     border: none;
     position: absolute;
-    top: 6rem;
+    top: 110%;
   }
 `;
 

--- a/src/components/home/searchFiltering/filteringContents/FilteringContents.tsx
+++ b/src/components/home/searchFiltering/filteringContents/FilteringContents.tsx
@@ -47,7 +47,7 @@ export default function FilteringContents() {
         {skillTagButtonToggle && (
           <div className='skillTagBox' onClick={handleSkillTagFilterClick}>
             <SkillTagBox
-              width='90%'
+              width='100%'
               selectSkills={selectSkills}
               setSelectSkills={setSelectSkills}
               reset={true}

--- a/src/components/home/searchFiltering/filteringContents/filtering/Filtering.styled.ts
+++ b/src/components/home/searchFiltering/filteringContents/filtering/Filtering.styled.ts
@@ -28,7 +28,7 @@ export const Wrapper = styled.div`
       border: 1px solid ${({ theme }) => theme.color.border};
       border-radius: 0.5rem;
       position: absolute;
-      top: 2.8rem;
+      top: 2.3rem;
       cursor: pointer;
       overflow: hidden;
       background-color: ${({ theme }) => theme.color.white};

--- a/src/components/home/searchFiltering/search/Search.styled.ts
+++ b/src/components/home/searchFiltering/search/Search.styled.ts
@@ -1,9 +1,8 @@
-import { XMarkIcon } from '@heroicons/react/24/outline';
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  width: 27rem;
-  height: 2.9rem;
+  width: 30vw;
+  padding: 0.6rem 0;
   display: flex;
   flex-direction: row;
   border: 1px solid ${({ theme }) => theme.color.border};
@@ -11,7 +10,7 @@ export const Container = styled.div`
 `;
 
 export const Wrapper = styled.div`
-  width: 100vw;
+  width: 100%;
   display: flex;
   align-items: center;
   form {


### PR DESCRIPTION
### 구현내용

- 메인 페이지 레이아웃 수정 (창 줄어들면 프로젝트 수와 필터링 레이아웃도 같이 줄어들도록 수정)
- 카드 스타일 수정

### 알림 사항
- 카드 제목 텍스트 생략 기능 넣어주세요!
- 카드 리스트는 줄어들지 않습니다 (이 부분도 형준님처럼 변하게 바꿔주시면 좋을듯 합니다:) )
- 필터링 레이아웃은 미디어쿼리 적용시 검색창이 아래로 내려가게 구현 예정입니다.

### 구현 UI

- 창 좁혔을때
![Screen Shot 2025-01-21 at 11 09 50 AM](https://github.com/user-attachments/assets/a1ace8da-ce67-4f3d-b074-044d61fb15e2)

- 카드 수정 디자인
![Screen Shot 2025-01-21 at 11 09 54 AM](https://github.com/user-attachments/assets/6c8de1d5-1492-4693-a525-6b8085f84af7)


### 연관이슈
 close #104
