### PR TITLE
헤더 프로필 기본이미지가 나오지 않는 이슈 (issue #214)

### DIFF
--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -20,7 +20,11 @@ function Header() {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const { myData, isLoading } = useMyProfileInfo();
 
-  const profileImg = myData?.profileImg || DefaultImg;
+  const profileImg = myData?.profileImg
+    ? `${import.meta.env.VITE_APP_IMAGE_CDN_URL}/${formatImgPath(
+        myData.profileImg
+      )}?w=86&h=86&fit=crop&crop=entropy&auto=format,enhance&q=60`
+    : DefaultImg;
 
   return (
     <S.HeaderContainer>
@@ -33,14 +37,7 @@ function Header() {
             isLoading ? (
               <Avatar size='45px' image={loadingImg} />
             ) : isLoggedIn ? (
-              <Avatar
-                size='45px'
-                image={`${
-                  import.meta.env.VITE_APP_IMAGE_CDN_URL
-                }/${formatImgPath(
-                  profileImg
-                )}?w=86&h=86&fit=crop&crop=entropy&auto=format,enhance&q=60`}
-              />
+              <Avatar size='45px' image={profileImg} />
             ) : (
               <UserCircleIcon color='#6D6D6D' width='48' height='48' />
             )


### PR DESCRIPTION
### 구현내용
기존에 CDN경로만 있었기에 프로필 기본이미지가 나오지 않았던 문제를
CDN경로와 기본이미지의 경로를 삼항연산자로 분리하여 해결했습니다.
![image](https://github.com/user-attachments/assets/9af543f0-ab17-4b10-a8e9-bcb799cab76b)

### 연관이슈
close #214 
