### PR TITLE
프로젝트 생성 후 관리페이지 리패치 이슈(issue 219)

### DIFF
--- a/src/hooks/useCreateProject.ts
+++ b/src/hooks/useCreateProject.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { FormData } from '../models/createProject';
 import { MODAL_MESSAGE } from '../constants/modalMessage';
 import { postProject } from '../api/joinProject.api';
@@ -6,6 +6,7 @@ import { Dispatch, SetStateAction } from 'react';
 import { useSaveSearchFiltering } from './useSaveSearchFiltering';
 import { ROUTES } from '../constants/routes';
 import { useNavigate } from 'react-router-dom';
+import { managedProjectKey } from './queries/keys';
 
 interface UseCreateProjectProps {
   handleModalOpen: (newMessage: string) => void;
@@ -18,6 +19,7 @@ const useCreateProject = ({
 }: UseCreateProjectProps) => {
   const navigate = useNavigate();
   const { handleUpdateFilters } = useSaveSearchFiltering();
+  const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: (formData: FormData) => postProject(formData),
@@ -25,6 +27,10 @@ const useCreateProject = ({
       handleModalOpen(MODAL_MESSAGE.createProjectSuccess);
       setIsSubmit(true);
       handleUpdateFilters('skillTag', []);
+
+      queryClient.invalidateQueries({
+        queryKey: [managedProjectKey.managedProjectList],
+      });
 
       setTimeout(() => {
         navigate(ROUTES.main);


### PR DESCRIPTION
### 구현내용
프로젝트 생성 후 managedProjectList을 쿼리 무효화하여 리패치 문제 해결했습니다.

### 연관이슈
close #219 
