### PR TITLE
헤더, 랜딩페이지 웹 접근성 대응 (issue #244)

### DIFF
--- a/src/components/common/dropDown/DropDown.tsx
+++ b/src/components/common/dropDown/DropDown.tsx
@@ -12,6 +12,7 @@ const DropDown = ({
   children,
   toggleButton,
   isOpen = false,
+  ...props
 }: DropDownProps) => {
   const [open, setOpen] = useState(isOpen);
   const dropdownRef = useOutsideClick(() => handleCloseModal());
@@ -21,7 +22,11 @@ const DropDown = ({
 
   return (
     <S.DropDownContainer ref={dropdownRef}>
-      <S.DropDownButtonWrapper onClick={() => setOpen(!open)}>
+      <S.DropDownButtonWrapper
+        onClick={() => setOpen(!open)}
+        tabIndex={0}
+        {...props}
+      >
         {toggleButton}
       </S.DropDownButtonWrapper>
       {open && <S.Panel>{children}</S.Panel>}

--- a/src/components/common/header/Header.styled.ts
+++ b/src/components/common/header/Header.styled.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const HeaderContainer = styled.div`
+export const HeaderContainer = styled.header`
   width: 100%;
   margin: 0 auto;
   max-width: ${({ theme }) => theme.layout.width.desktop};
@@ -17,7 +17,7 @@ export const HeaderContainer = styled.div`
   }
 `;
 
-export const Wrapper = styled.nav`
+export const Wrapper = styled.div`
   display: flex;
 `;
 
@@ -45,9 +45,8 @@ export const LogoImg = styled.img`
 
 export const HeaderLinkContainer = styled.div`
   display: flex;
-  justify-center: center;
+  justify-content: center;
   align-items: center;
-  // item과 content의 차이가 뭘까?
 `;
 
 export const List = styled.ul`
@@ -82,7 +81,7 @@ export const List = styled.ul`
   }
 `;
 
-export const HeaderLink = styled.span`
+export const HeaderLink = styled.p`
   font-size: 1.2rem;
   font-weight: bold;
   text-align: center;

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -32,7 +32,7 @@ function Header() {
   return (
     <S.HeaderContainer>
       <Link to={ROUTES.main}>
-        <S.LogoImg src={Mainlogo} alt='logo' />
+        <S.LogoImg src={Mainlogo} alt='logo' aria-label='메인로고' />
       </Link>
       <S.Wrapper>
         <S.HeaderLinkContainer>
@@ -43,7 +43,7 @@ function Header() {
             <S.HeaderLink>공지사항</S.HeaderLink>
           </Link>
         </S.HeaderLinkContainer>
-        <S.Alarm>
+        <S.Alarm role='button' tabIndex={0} aria-label='알림 메세지'>
           {isLoggedIn ? (
             <DropDown toggleButton={<img src={bellLogined} />}>
               <Notification />
@@ -54,6 +54,7 @@ function Header() {
           )}
         </S.Alarm>
         <DropDown
+          aria-label='프로필 드롭다운'
           toggleButton={
             isLoading ? (
               <Avatar size='45px' image={loadingImg} />
@@ -77,17 +78,26 @@ function Header() {
                   <S.Item>문의하기</S.Item>
                 </Link>
                 <Link to='#' onClick={(e) => e.preventDefault()}>
-                  <S.Item onClick={userLogout}>로그아웃</S.Item>
+                  <S.Item
+                    aria-label='클릭시 로그아웃 됩니다.'
+                    onClick={userLogout}
+                  >
+                    로그아웃
+                  </S.Item>
                 </Link>
               </S.List>
             )}
             {!isLoggedIn && (
               <S.List>
                 <Link to={ROUTES.login}>
-                  <S.Item>로그인</S.Item>
+                  <S.Item aria-label='클릭시 로그인 화면으로 이동합니다.'>
+                    로그인
+                  </S.Item>
                 </Link>
                 <Link to={ROUTES.signup}>
-                  <S.Item>회원가입</S.Item>
+                  <S.Item aria-label='클릭시 회원가입 화면으로 이동합니다.'>
+                    회원가입
+                  </S.Item>
                 </Link>
               </S.List>
             )}

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -45,12 +45,12 @@ function Header() {
         </S.HeaderLinkContainer>
         <S.Alarm role='button' tabIndex={0} aria-label='알림 메세지'>
           {isLoggedIn ? (
-            <DropDown toggleButton={<img src={bellLogined} />}>
+            <DropDown toggleButton={<img src={bellLogined} alt='알림' />}>
               <Notification />
               {/* {isSignal && '가능'} */}
             </DropDown>
           ) : (
-            <img src={bell} />
+            <img src={bell} alt='알림' />
           )}
         </S.Alarm>
         <DropDown

--- a/src/pages/main/About.styled.ts
+++ b/src/pages/main/About.styled.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const Container = styled.div<{ $isVisible: boolean }>`
+export const Container = styled.section<{ $isVisible: boolean }>`
   width: 100%;
   height: 100vh;
   display: flex;

--- a/src/pages/main/HeroSection.styled.ts
+++ b/src/pages/main/HeroSection.styled.ts
@@ -2,7 +2,7 @@ import styled, { keyframes } from 'styled-components';
 export const Container = styled.div`
   max-width: ${({ theme }) => theme.layout.width.desktop};
 `;
-export const MainContainer = styled.div`
+export const MainContainer = styled.section`
   display: flex;
   width: 100%;
   height: 100vh;

--- a/src/pages/main/HeroSection.tsx
+++ b/src/pages/main/HeroSection.tsx
@@ -20,18 +20,34 @@ const HeroSection = ({ handleScrollToSection }: HeroSectionProps) => {
         </S.Title>
       </S.ImgWrapper>
       <S.ButtonWrapper>
-        <Link to={ROUTES.main}>
-          <Button size='primary' schema='primary' radius='large'>
+        <Link to={ROUTES.main} role='none'>
+          <Button
+            size='primary'
+            schema='primary'
+            radius='large'
+            aria-label='클릭시 프로젝트보기 페이지로 이동합니다.'
+          >
             프로젝트보기
           </Button>
         </Link>
-        <Link to={ROUTES.createProject}>
-          <Button size='primary' schema='primary' radius='large'>
+        <Link to={ROUTES.createProject} role='none'>
+          <Button
+            size='primary'
+            schema='primary'
+            radius='large'
+            aria-label='클릭시 팀원모집하기 페이지로 이동합니다.'
+          >
             팀원모집하기
           </Button>
         </Link>
       </S.ButtonWrapper>
-      <S.DownArrow src={DownArrow} onClick={() => handleScrollToSection(0)} />
+      <S.DownArrow
+        src={DownArrow}
+        onClick={() => handleScrollToSection(0)}
+        role='button'
+        tabIndex={0}
+        alt='아래로 스크롤하는 화살표 아이콘'
+      />
     </S.MainContainer>
   );
 };

--- a/src/pages/manage/myProjectParticipantsPass/MyProjectVolunteersPass.tsx
+++ b/src/pages/manage/myProjectParticipantsPass/MyProjectVolunteersPass.tsx
@@ -5,7 +5,7 @@ import { applicantsMenuItems } from '../../../constants/sidebarItems';
 import InfoCard from '../../../components/common/infoCard/InfoCard';
 import MainLogo from '../../../assets/mainlogo.svg';
 import { usePassNonPassList } from '../../../hooks/usePassNonPassList';
-import useGetProjectData from '../../../hooks/useJoinProject';
+import useGetProjectData from '../../../hooks/useGetProjectData';
 import ProjectHeader from '../../../components/manageProjects/ProjectHeader';
 import PassNonPassList from '../../../components/manageProjects/passNonPassList/PassNonPassList';
 import NoContent from '../../../components/common/noContent/NoContent';


### PR DESCRIPTION
### 구현내용
헤더와 랜딩페이지에 웹 접근성을 적용합니다

### 연관이슈
close #244 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 드롭다운 컴포넌트에 임의의 속성을 전달할 수 있도록 확장되었습니다.
- **Refactor**
  - 헤더, 히어로 섹션, 소개 영역 등 주요 레이아웃 컴포넌트의 HTML 태그가 더 의미 있는 시맨틱 태그로 변경되었습니다.
  - 일부 스타일 컴포넌트의 잘못된 CSS 속성이 수정되었습니다.
  - 프로젝트 참가자 페이지에서 프로젝트 데이터 훅의 import가 올바르게 수정되었습니다.
- **Style**
  - 불필요한 주석이 제거되고, 텍스트 요소의 태그가 보다 적절하게 변경되었습니다.
- **Bug Fixes**
  - 드롭다운 및 헤더 등에서 접근성(ARIA 속성, tabIndex 등)이 개선되어 키보드 및 스크린리더 사용성이 향상되었습니다.
  - 히어로 섹션 내 버튼 및 아이콘에 접근성 속성이 추가되어 사용자 경험이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->