### PR TITLE
fix : styled-component 빌드 에러 수정 (issue #266)

### DIFF
--- a/src/components/manageProjects/Card.styled.ts
+++ b/src/components/manageProjects/Card.styled.ts
@@ -54,7 +54,7 @@ export const CardTitle = styled.h3`
 export const RecruitmentDate = styled.small`
   font-size: ${({ theme }) => theme.heading.small.fontSize};
   font-weight: 400;
-  color: ${({ theme }) => theme.color.deepgrey};
+  color: ${({ theme }) => theme.color.deepGrey};
   margin-bottom: 0.25rem;
 
   @media ${({ theme }) => theme.mediaQuery.tablet} {
@@ -66,7 +66,7 @@ export const RecruitmentDate = styled.small`
 export const TotalMember = styled.small`
   font-size: ${({ theme }) => theme.heading.small.fontSize};
   font-weight: 400;
-  color: ${({ theme }) => theme.color.deepgrey};
+  color: ${({ theme }) => theme.color.deepGrey};
   margin-bottom: 1.125rem;
 
   @media ${({ theme }) => theme.mediaQuery.tablet} {

--- a/src/components/manageProjects/RecruitmentDate.styled.ts
+++ b/src/components/manageProjects/RecruitmentDate.styled.ts
@@ -32,7 +32,7 @@ export const DateTag = styled.span`
 export const Period = styled.small`
   font-size: ${({ theme }) => theme.heading.small.fontSize};
   font-weight: 500;
-  color: ${({ theme }) => theme.color.deepgrey};
+  color: ${({ theme }) => theme.color.deepGrey};
 
   @media ${({ theme }) => theme.mediaQuery.tablet} {
     font-size: ${({ theme }) => theme.heading.small.tabletFontSize};

--- a/src/pages/apply/Apply.styled.ts
+++ b/src/pages/apply/Apply.styled.ts
@@ -58,7 +58,7 @@ export const Section = styled.div`
 export const Label = styled.label`
   font-size: 1.2rem;
   font-weight: bold;
-  color: ${({ theme }) => theme.color.black};
+  color: ${({ theme }) => theme.color.primary};
 
   @media ${({ theme }) => theme.mediaQuery.tablet} {
     font-size: 1.1rem;

--- a/src/pages/apply/ApplyStep.styled.ts
+++ b/src/pages/apply/ApplyStep.styled.ts
@@ -52,7 +52,7 @@ export const StepButton = styled.div`
 export const StepLabel = styled.div`
   font-size: 1rem;
   font-weight: bold;
-  color: ${({ theme }) => theme.color.black};
+  color: ${({ theme }) => theme.color.primary};
   margin-bottom: 10px;
 
   @media ${({ theme }) => theme.mediaQuery.tablet} {

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -30,7 +30,7 @@ export type BorderRadiusSize = 'primary' | 'large' | 'small';
 
 export type MediaQuery = 'mobile' | 'tablet' | 'desktop';
 
-interface Theme {
+export interface Theme {
   color: Record<ColorKey, string>;
   heading: {
     [key in HeadingSize]: {

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -1,0 +1,6 @@
+import 'styled-components';
+import { Theme } from './style/theme';
+
+declare module 'styled-components' {
+  export interface DefaultTheme extends Theme {}
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src", "src/styled.d.ts"]
 }


### PR DESCRIPTION
### 구현내용

- styled-component v5 -> v6로 업그레이드 되며 theme 인터페이스를 DefaultTheme으로 등록하지 않으면 theme을 인식하지 못하는 에러 해결
- 현재 theme에 맞지 않은 네이밍 수정

### 연관이슈

close #266 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 일부 컴포넌트의 색상 테마 키 대소문자 오류를 수정하여 일관성을 개선했습니다.
  - 지원 페이지의 라벨 및 단계 라벨 색상을 기본 색상에서 주요 색상으로 변경했습니다.

- **Chores**
  - 테마 타입을 외부에서 사용할 수 있도록 공개했습니다.
  - 스타일드 컴포넌트의 테마 타입을 확장하여 타입 안정성을 높였습니다.
  - 타입스크립트 설정에 테마 타입 선언 파일을 명시적으로 포함시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->