### PR TITLE
문의하기 개선 (#issue 269)

### DIFF
--- a/src/api/inquiry.api.ts
+++ b/src/api/inquiry.api.ts
@@ -1,13 +1,13 @@
+import type { ApiCommonBasicType } from '../models/apiCommon';
 import { httpClient } from './http.api';
 
 export const postInquiry = async (formData: FormData) => {
   try {
-    const response = await httpClient.post('/inquiry', formData, {
+    await httpClient.post<ApiCommonBasicType>('/inquiry', formData, {
       headers: {
         'Content-Type': 'multipart/form-data',
       },
     });
-    console.log(response);
   } catch (e) {
     console.error('문의하기 에러', e);
     throw e;

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -1,6 +1,6 @@
 import * as S from './Header.styled';
 import Mainlogo from '../../../assets/mainlogo.svg';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import DropDown from '../dropDown/DropDown';
 import Avatar from '../avatar/Avatar';
 import { useAuth } from '../../../hooks/useAuth';
@@ -16,20 +16,22 @@ import { formatImgPath } from '../../../util/formatImgPath';
 import bell from '../../../assets/bell.svg';
 import Notification from './Notification/Notification';
 import bellLogined from '../../../assets/bellLogined.svg';
-// import useNotification from '../../../hooks/useNotification';
+import useNotification from '../../../hooks/useNotification';
 import { useEffect } from 'react';
 import { testLiveAlarm } from '../../../api/alarm.api';
 
 function Header() {
+  const location = useLocation();
   const { isOpen, message, handleModalOpen, handleModalClose } = useModal();
   const { userLogout } = useAuth(handleModalOpen);
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const { myData, isLoading } = useMyProfileInfo();
+
   // const { signalData, setSignalData } = useNotification();
 
-  useEffect(() => {
-    testLiveAlarm();
-  }, []);
+  // useEffect(() => {
+  //   testLiveAlarm();
+  // }, []);
 
   const profileImg = myData?.profileImg
     ? `${import.meta.env.VITE_APP_IMAGE_CDN_URL}/${formatImgPath(
@@ -95,7 +97,11 @@ function Header() {
                 <Link to={ROUTES.inquiry}>
                   <S.Item>문의하기</S.Item>
                 </Link>
-                <Link to='#' onClick={(e) => e.preventDefault()}>
+                <Link
+                  to='#'
+                  state={{ from: location.pathname }}
+                  onClick={(e) => e.preventDefault()}
+                >
                   <S.Item
                     aria-label='클릭시 로그아웃 됩니다.'
                     onClick={userLogout}

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -94,14 +94,10 @@ function Header() {
                 <Link to={ROUTES.manageProjectsRoot}>
                   <S.Item>공고관리</S.Item>
                 </Link>
-                <Link to={ROUTES.inquiry}>
+                <Link to={ROUTES.inquiry} state={{ from: location.pathname }}>
                   <S.Item>문의하기</S.Item>
                 </Link>
-                <Link
-                  to='#'
-                  state={{ from: location.pathname }}
-                  onClick={(e) => e.preventDefault()}
-                >
+                <Link to='#' onClick={(e) => e.preventDefault()}>
                   <S.Item
                     aria-label='클릭시 로그아웃 됩니다.'
                     onClick={userLogout}

--- a/src/components/mypage/activityLog/inquiries/inquiry/Inquiry.tsx
+++ b/src/components/mypage/activityLog/inquiries/inquiry/Inquiry.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { MyInquiries } from '../../../../../models/activityLog';
 import * as S from './Inquiry.styled';
-import { INQUIRY_MESSAGE } from '../../../../../constants/customerService';
+import { My_INQUIRIES_MESSAGE } from '../../../../../constants/customerService';
 
 interface InquiryProps {
   list: MyInquiries;
@@ -49,7 +49,7 @@ export default function Inquiry({ list, no }: InquiryProps) {
                 ))}
               </S.InquiryImgWrapper>
               <S.MessageWrapper>
-                {INQUIRY_MESSAGE.blowUpMessage}
+                {My_INQUIRIES_MESSAGE.blowUpMessage}
               </S.MessageWrapper>
             </S.InquiryImgContainer>
           )}
@@ -64,7 +64,7 @@ export default function Inquiry({ list, no }: InquiryProps) {
                 }
               >
                 <S.ModalImgMessageWrapper>
-                  {INQUIRY_MESSAGE.isImageOpenMessage}
+                  {My_INQUIRIES_MESSAGE.isImageOpenMessage}
                 </S.ModalImgMessageWrapper>
                 <S.ModalImg src={isImageOpen.url} />
               </S.ModalImgWrapper>

--- a/src/constants/customerService.ts
+++ b/src/constants/customerService.ts
@@ -8,9 +8,17 @@ export const INQUIRY_CATEGORY = [
 export const EMPTY_IMAGE =
   'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7' as const;
 
-export const INQUIRY_MESSAGE = {
+export const My_INQUIRIES_MESSAGE = {
   categoryDefault: '카테고리',
   fileDefault: '선택된 파일이 없습니다.',
   blowUpMessage: '클릭하면 이미지를 크게 볼 수 있습니다.',
   isImageOpenMessage: '이미지를 클릭하면 사라집니다.',
+};
+
+export const INQUIRY_MESSAGE = {
+  selectCategory: '카테고리를 선택하세요.',
+  writeTitle: '제목을 적어주세요.',
+  writeContent: '내용을 적어주세요.',
+  inquiredSuccess: '문의글이 작성되었습니다.',
+  inquiredError: '문의글 작성에 실패하였습니다.',
 };

--- a/src/constants/customerService.ts
+++ b/src/constants/customerService.ts
@@ -21,4 +21,5 @@ export const INQUIRY_MESSAGE = {
   writeContent: '내용을 적어주세요.',
   inquiredSuccess: '문의글이 작성되었습니다.',
   inquiredError: '문의글 작성에 실패하였습니다.',
+  validationFile: '파일 크기는 5MB 이하만 가능합니다.',
 };

--- a/src/hooks/useMyInfo.ts
+++ b/src/hooks/useMyInfo.ts
@@ -24,7 +24,7 @@ export const useMyProfileInfo = () => {
   const { data, isLoading } = useQuery<ApiUserInfo>({
     queryKey: myInfoKey.myProfile,
     queryFn: () => getMyInfo(),
-    staleTime: 1 * 60 * 1000,
+    staleTime: Infinity,
     enabled: isLoggedIn,
   });
 

--- a/src/hooks/usePostInquiry.ts
+++ b/src/hooks/usePostInquiry.ts
@@ -4,8 +4,12 @@ import { postInquiry } from '../api/inquiry.api';
 import { AxiosError } from 'axios';
 import useAuthStore from '../store/authStore';
 import { useNavigate } from 'react-router-dom';
+import { INQUIRY_MESSAGE } from '../constants/customerService';
 
-export const usePostInquiry = (pathname: string) => {
+export const usePostInquiry = (
+  pathname: string,
+  handleModalOpen: (message: string) => void
+) => {
   const userId = useAuthStore((state) => state.userData?.id);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -16,7 +20,13 @@ export const usePostInquiry = (pathname: string) => {
       queryClient.invalidateQueries({
         queryKey: [ActivityLog.myInquiries, userId],
       });
-      navigate(pathname);
+      setTimeout(() => {
+        navigate(pathname);
+      }, 1000);
+      handleModalOpen(INQUIRY_MESSAGE.inquiredSuccess);
+    },
+    onError: () => {
+      handleModalOpen(INQUIRY_MESSAGE.inquiredError);
     },
   });
 

--- a/src/hooks/usePostInquiry.ts
+++ b/src/hooks/usePostInquiry.ts
@@ -7,8 +7,8 @@ import { useNavigate } from 'react-router-dom';
 import { INQUIRY_MESSAGE } from '../constants/customerService';
 
 export const usePostInquiry = (
-  pathname: string,
-  handleModalOpen: (message: string) => void
+  handleModalOpen: (message: string) => void,
+  pathname: string = ''
 ) => {
   const userId = useAuthStore((state) => state.userData?.id);
   const navigate = useNavigate();
@@ -21,8 +21,13 @@ export const usePostInquiry = (
         queryKey: [ActivityLog.myInquiries, userId],
       });
       setTimeout(() => {
-        navigate(pathname);
+        if (pathname === '' || !pathname) {
+          navigate(-1);
+        } else {
+          navigate(pathname);
+        }
       }, 1000);
+
       handleModalOpen(INQUIRY_MESSAGE.inquiredSuccess);
     },
     onError: () => {

--- a/src/hooks/usePostInquiry.ts
+++ b/src/hooks/usePostInquiry.ts
@@ -1,14 +1,22 @@
+import { ActivityLog } from './queries/keys';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postInquiry } from '../api/inquiry.api';
 import { AxiosError } from 'axios';
+import useAuthStore from '../store/authStore';
+import { useNavigate } from 'react-router-dom';
 
-export const usePostInquiry = () => {
+export const usePostInquiry = (pathname: string) => {
+  const userId = useAuthStore((state) => state.userData?.id);
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
 
   const mutate = useMutation<void, AxiosError, FormData>({
     mutationFn: (formData) => postInquiry(formData),
     onSuccess: () => {
-      queryClient.invalidateQueries();
+      queryClient.invalidateQueries({
+        queryKey: [ActivityLog.myInquiries, userId],
+      });
+      navigate(pathname);
     },
   });
 

--- a/src/models/apiCommon.ts
+++ b/src/models/apiCommon.ts
@@ -3,6 +3,10 @@ export interface ApiCommonType {
   message: string;
 }
 
+export interface ApiCommonBasicType extends ApiCommonType {
+  data: boolean;
+}
+
 export interface User {
   id: number;
   nickname: string;

--- a/src/pages/customerService/MoveInquiredLink.tsx
+++ b/src/pages/customerService/MoveInquiredLink.tsx
@@ -1,6 +1,13 @@
+import { useLocation } from 'react-router-dom';
 import { ROUTES } from '../../constants/routes';
 import * as S from './MoveInquiredLink.styled';
 
 export default function MovedInquiredLink() {
-  return <S.MoveInquiredLink to={ROUTES.inquiry}>문의하기</S.MoveInquiredLink>;
+  const location = useLocation();
+
+  return (
+    <S.MoveInquiredLink to={ROUTES.inquiry} state={{ from: location.pathname }}>
+      문의하기
+    </S.MoveInquiredLink>
+  );
 }

--- a/src/pages/customerService/inquiry/Inquiry.styled.ts
+++ b/src/pages/customerService/inquiry/Inquiry.styled.ts
@@ -35,7 +35,7 @@ export const CategoryWrapper = styled.div`
   position: relative;
 `;
 
-export const CategorySelect = styled.button<{ $isOpen: boolean }>`
+export const CategorySelect = styled.button<{ $isCategoryOpen: boolean }>`
   padding: 0.3rem 0.5rem;
   width: 9rem;
   display: flex;

--- a/src/pages/customerService/inquiry/Inquiry.tsx
+++ b/src/pages/customerService/inquiry/Inquiry.tsx
@@ -1,13 +1,14 @@
 import { Fragment } from 'react/jsx-runtime';
 import {
   INQUIRY_CATEGORY,
-  INQUIRY_MESSAGE,
+  My_INQUIRIES_MESSAGE,
 } from '../../../constants/customerService';
 import * as S from './Inquiry.styled';
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
 import React, { useEffect, useState } from 'react';
 import type { InquiryFormData } from '../../../models/inquiry';
 import { usePostInquiry } from '../../../hooks/usePostInquiry';
+import { useLocation } from 'react-router-dom';
 
 interface FormStateType {
   category: string;
@@ -18,13 +19,14 @@ interface FormStateType {
 }
 
 export default function Inquiry() {
-  const { mutate: postInquiry } = usePostInquiry();
+  const location = useLocation();
+  const { mutate: postInquiry } = usePostInquiry(location.state.from);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [form, setForm] = useState<FormStateType>({
-    category: INQUIRY_MESSAGE.categoryDefault,
+    category: My_INQUIRIES_MESSAGE.categoryDefault,
     title: '',
     content: '',
-    fileValue: INQUIRY_MESSAGE.fileDefault,
+    fileValue: My_INQUIRIES_MESSAGE.fileDefault,
     fileImage: null,
   });
 
@@ -49,7 +51,7 @@ export default function Inquiry() {
     let isValid = true;
 
     Array.from(formData.entries()).forEach(([key, value]) => {
-      if (key === 'category' && value === INQUIRY_MESSAGE.categoryDefault)
+      if (key === 'category' && value === My_INQUIRIES_MESSAGE.categoryDefault)
         return (isValid = false);
       if (key === 'title' && value === '') return (isValid = false);
       if (key === 'content' && value === '') return (isValid = false);
@@ -58,10 +60,10 @@ export default function Inquiry() {
     if (isValid) {
       postInquiry(formData);
       setForm({
-        category: INQUIRY_MESSAGE.categoryDefault,
+        category: My_INQUIRIES_MESSAGE.categoryDefault,
         title: '',
         content: '',
-        fileValue: INQUIRY_MESSAGE.fileDefault,
+        fileValue: My_INQUIRIES_MESSAGE.fileDefault,
         fileImage: null,
       });
     }
@@ -76,6 +78,7 @@ export default function Inquiry() {
     const image = e.target.files?.[0];
 
     // 파일 크기 제한 (예: 5MB)
+    // 모달처리
     const MAX_FILE_SIZE = 5 * 1024 * 1024;
     if (image && image.size > MAX_FILE_SIZE) {
       alert('파일 크기는 5MB 이하만 가능합니다.');

--- a/src/pages/customerService/inquiry/Inquiry.tsx
+++ b/src/pages/customerService/inquiry/Inquiry.tsx
@@ -9,6 +9,8 @@ import React, { useEffect, useState } from 'react';
 import type { InquiryFormData } from '../../../models/inquiry';
 import { usePostInquiry } from '../../../hooks/usePostInquiry';
 import { useLocation } from 'react-router-dom';
+import { useModal } from '../../../hooks/useModal';
+import Modal from '../../../components/common/modal/Modal';
 
 interface FormStateType {
   category: string;
@@ -20,7 +22,17 @@ interface FormStateType {
 
 export default function Inquiry() {
   const location = useLocation();
-  const { mutate: postInquiry } = usePostInquiry(location.state.from);
+
+  const {
+    isOpen: isModalOpen,
+    message,
+    handleModalOpen,
+    handleModalClose,
+  } = useModal();
+  const { mutate: postInquiry } = usePostInquiry(
+    location.state.from,
+    handleModalOpen
+  );
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [form, setForm] = useState<FormStateType>({
     category: My_INQUIRIES_MESSAGE.categoryDefault,
@@ -173,6 +185,9 @@ export default function Inquiry() {
           </S.SendButtonWrapper>
         </S.InquiryWrapper>
       </S.InquiryForm>
+      <Modal isOpen={isModalOpen} onClose={handleModalClose}>
+        {message}
+      </Modal>
     </S.Container>
   );
 }

--- a/src/pages/customerService/inquiry/Inquiry.tsx
+++ b/src/pages/customerService/inquiry/Inquiry.tsx
@@ -30,13 +30,10 @@ export default function Inquiry() {
     handleModalClose,
   } = useModal();
   const { mutate: postInquiry } = usePostInquiry(
-    location.state.from,
-    handleModalOpen
+    handleModalOpen,
+    location.state.from || ''
   );
-  const [isOpen, setIsOpen] = useState<{
-    category: boolean;
-    submitButton: boolean;
-  }>({ category: false, submitButton: false });
+  const [isCategoryOpen, setIsCategoryOpen] = useState<boolean>(false);
   const [form, setForm] = useState<FormStateType>({
     category: My_INQUIRIES_MESSAGE.categoryDefault,
     title: '',
@@ -62,56 +59,43 @@ export default function Inquiry() {
 
     formData.append('inquiryDto', data);
 
-    const isValid = { category: false, title: false, content: false };
+    const isValid = {
+      category: form.category !== My_INQUIRIES_MESSAGE.categoryDefault,
+      title: form.title.trim() !== '',
+      content: form.content.trim() !== '',
+    };
 
-    if (isOpen.submitButton) {
-      for (const [key, value] of formData.entries()) {
-        if (
-          key === 'category' &&
-          value === My_INQUIRIES_MESSAGE.categoryDefault
-        ) {
-          handleModalOpen(INQUIRY_MESSAGE.selectCategory);
-          return (isValid.category = false);
-        } else if (key === 'title' && value === '') {
-          handleModalOpen(INQUIRY_MESSAGE.writeTitle);
-          return (isValid.title = false);
-        } else if (key === 'content' && value === '') {
-          handleModalOpen(INQUIRY_MESSAGE.writeContent);
-          return (isValid.content = false);
-        }
-      }
+    if (!isValid.category) {
+      return handleModalOpen(INQUIRY_MESSAGE.selectCategory);
+    }
+    if (!isValid.title) {
+      return handleModalOpen(INQUIRY_MESSAGE.writeTitle);
+    }
+    if (!isValid.content) {
+      return handleModalOpen(INQUIRY_MESSAGE.writeContent);
     }
 
-    setIsOpen((prev) => ({ ...prev, submitButton: false }));
-
-    if (isValid.category && isValid.title && isValid.content) {
-      postInquiry(formData);
-      setForm({
-        category: My_INQUIRIES_MESSAGE.categoryDefault,
-        title: '',
-        content: '',
-        fileValue: My_INQUIRIES_MESSAGE.fileDefault,
-        fileImage: null,
-      });
-    }
+    postInquiry(formData);
+    setForm({
+      category: My_INQUIRIES_MESSAGE.categoryDefault,
+      title: '',
+      content: '',
+      fileValue: My_INQUIRIES_MESSAGE.fileDefault,
+      fileImage: null,
+    });
   };
 
   const handleClickCategoryValue = (category: string) => {
     setForm((prev) => ({ ...prev, category }));
-    setIsOpen((prev) => ({
-      ...prev,
-      category: !prev.category,
-    }));
+    setIsCategoryOpen((prev) => !prev);
   };
   const handleChangeFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const fileValue = e.target.value;
     const image = e.target.files?.[0];
 
-    // 파일 크기 제한 (예: 5MB)
-    // 모달처리
     const MAX_FILE_SIZE = 5 * 1024 * 1024;
     if (image && image.size > MAX_FILE_SIZE) {
-      alert('파일 크기는 5MB 이하만 가능합니다.');
+      handleModalOpen(INQUIRY_MESSAGE.validationFile);
       e.target.value = '';
       return;
     }
@@ -142,14 +126,12 @@ export default function Inquiry() {
           <S.Nav>
             <S.CategoryWrapper>
               <S.CategorySelect
+                type='button'
                 onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                   e.stopPropagation();
-                  setIsOpen((prev) => ({
-                    ...prev,
-                    category: !prev.category,
-                  }));
+                  setIsCategoryOpen((prev) => !prev);
                 }}
-                $isOpen={isOpen.category}
+                $isCategoryOpen={isCategoryOpen}
               >
                 {form.category} <ChevronDownIcon />
                 <S.CategoryValueInput
@@ -158,11 +140,12 @@ export default function Inquiry() {
                   value={form.category}
                 />
               </S.CategorySelect>
-              {isOpen.category && (
+              {isCategoryOpen && (
                 <S.CategoryButtonWrapper>
                   {INQUIRY_CATEGORY.map((category) => (
                     <Fragment key={category.title}>
                       <S.CategoryButton
+                        type='button'
                         onClick={() => handleClickCategoryValue(category.title)}
                       >
                         {category.title}
@@ -207,12 +190,7 @@ export default function Inquiry() {
           <S.SendButtonWrapper>
             <S.SendButton
               type='submit'
-              onClick={() =>
-                setIsOpen((prev) => ({
-                  ...prev,
-                  submitButton: true,
-                }))
-              }
+              onClick={() => setIsCategoryOpen((prev) => !prev)}
             >
               제출
             </S.SendButton>

--- a/src/pages/customerService/inquiry/Inquiry.tsx
+++ b/src/pages/customerService/inquiry/Inquiry.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react/jsx-runtime';
 import {
   INQUIRY_CATEGORY,
+  INQUIRY_MESSAGE,
   My_INQUIRIES_MESSAGE,
 } from '../../../constants/customerService';
 import * as S from './Inquiry.styled';
@@ -22,7 +23,6 @@ interface FormStateType {
 
 export default function Inquiry() {
   const location = useLocation();
-
   const {
     isOpen: isModalOpen,
     message,
@@ -33,7 +33,10 @@ export default function Inquiry() {
     location.state.from,
     handleModalOpen
   );
-  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isOpen, setIsOpen] = useState<{
+    category: boolean;
+    submitButton: boolean;
+  }>({ category: false, submitButton: false });
   const [form, setForm] = useState<FormStateType>({
     category: My_INQUIRIES_MESSAGE.categoryDefault,
     title: '',
@@ -59,17 +62,31 @@ export default function Inquiry() {
 
     formData.append('inquiryDto', data);
 
-    // 모달처리하기
-    let isValid = true;
+    const isValid = { category: false, title: false, content: false };
 
-    Array.from(formData.entries()).forEach(([key, value]) => {
-      if (key === 'category' && value === My_INQUIRIES_MESSAGE.categoryDefault)
-        return (isValid = false);
-      if (key === 'title' && value === '') return (isValid = false);
-      if (key === 'content' && value === '') return (isValid = false);
-    });
+    if (isOpen.submitButton) {
+      console.log('제출하기버튼*-*-*-*-*-*', isOpen.submitButton);
 
-    if (isValid) {
+      for (const [key, value] of formData.entries()) {
+        if (
+          key === 'category' &&
+          value === My_INQUIRIES_MESSAGE.categoryDefault
+        ) {
+          handleModalOpen(INQUIRY_MESSAGE.selectCategory);
+          return (isValid.category = false);
+        } else if (key === 'title' && value === '') {
+          handleModalOpen(INQUIRY_MESSAGE.writeTitle);
+          return (isValid.title = false);
+        } else if (key === 'content' && value === '') {
+          handleModalOpen(INQUIRY_MESSAGE.writeContent);
+          return (isValid.content = false);
+        }
+      }
+    }
+
+    setIsOpen((prev) => ({ ...prev, submitButton: false }));
+
+    if (isValid.category && isValid.title && isValid.content) {
       postInquiry(formData);
       setForm({
         category: My_INQUIRIES_MESSAGE.categoryDefault,
@@ -83,7 +100,10 @@ export default function Inquiry() {
 
   const handleClickCategoryValue = (category: string) => {
     setForm((prev) => ({ ...prev, category }));
-    setIsOpen((prev) => !prev);
+    setIsOpen((prev) => ({
+      ...prev,
+      category: !prev.category,
+    }));
   };
   const handleChangeFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const fileValue = e.target.value;
@@ -124,8 +144,14 @@ export default function Inquiry() {
           <S.Nav>
             <S.CategoryWrapper>
               <S.CategorySelect
-                onClick={() => setIsOpen((prev) => !prev)}
-                $isOpen={isOpen}
+                onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                  e.stopPropagation();
+                  setIsOpen((prev) => ({
+                    ...prev,
+                    category: !prev.category,
+                  }));
+                }}
+                $isOpen={isOpen.category}
               >
                 {form.category} <ChevronDownIcon />
                 <S.CategoryValueInput
@@ -134,7 +160,7 @@ export default function Inquiry() {
                   value={form.category}
                 />
               </S.CategorySelect>
-              {isOpen && (
+              {isOpen.category && (
                 <S.CategoryButtonWrapper>
                   {INQUIRY_CATEGORY.map((category) => (
                     <Fragment key={category.title}>
@@ -181,7 +207,17 @@ export default function Inquiry() {
             </S.InquiryFileWrapper>
           </S.ContentWrapper>
           <S.SendButtonWrapper>
-            <S.SendButton type='submit'>제출</S.SendButton>
+            <S.SendButton
+              type='submit'
+              onClick={() =>
+                setIsOpen((prev) => ({
+                  ...prev,
+                  submitButton: true,
+                }))
+              }
+            >
+              제출
+            </S.SendButton>
           </S.SendButtonWrapper>
         </S.InquiryWrapper>
       </S.InquiryForm>

--- a/src/pages/customerService/inquiry/Inquiry.tsx
+++ b/src/pages/customerService/inquiry/Inquiry.tsx
@@ -65,8 +65,6 @@ export default function Inquiry() {
     const isValid = { category: false, title: false, content: false };
 
     if (isOpen.submitButton) {
-      console.log('제출하기버튼*-*-*-*-*-*', isOpen.submitButton);
-
       for (const [key, value] of formData.entries()) {
         if (
           key === 'category' &&


### PR DESCRIPTION
### 구현내용

send-alarm 주석처리 (에러 의심)
문의하기 페이지로 넘어올 때 작성 후 다시 머무르던 페이지로 이동 기능 구현
문의하기 각 값이 없을 때 모달창 띄워주기
문의하기 작성 완료시 성공 모달 띄워주기
문의하기 mutate error 모달 처리

### 연관이슈

close #269 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 문의 등록 시 유효성 검사 및 안내 메시지가 알림창(alert) 대신 모달로 표시됩니다.
  - 문의 제출 성공 또는 실패 시 모달을 통해 안내 메시지가 제공됩니다.

- **개선사항**
  - 문의 제출 후 1초 뒤 자동으로 지정된 경로로 이동합니다.
  - 문의 관련 메시지와 라벨이 상황에 따라 세분화되어 더 명확하게 안내됩니다.
  - 문의 내역 이동 링크 및 헤더 메뉴에서 현재 위치 정보가 유지되어 더 자연스러운 이동이 가능합니다.
  - 문의 카테고리 선택 드롭다운 UI 상태 관리가 개선되었습니다.
  - 사용자 프로필 정보 캐시 유지 시간이 무한대로 변경되어 불필요한 재요청이 줄어듭니다.

- **버그 수정**
  - 문의 작성 시 각 입력 필드별 유효성 검사가 세분화되어, 보다 정확한 입력 안내가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->