### PR TITLE
로그인 화면 세로 중간정렬 수정 (#issue 282)

### DIFF
--- a/src/pages/login/Login.styled.ts
+++ b/src/pages/login/Login.styled.ts
@@ -1,18 +1,20 @@
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 export const Container = styled.div`
   display: flex;
   width: 100%;
+  height: 100vh;
   max-width: ${({ theme }) => theme.layout.width.desktop};
   min-width: 310px;
   margin: 0 auto;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
 
   img {
     width: 6.5rem;
     height: 6.5rem;
-    margin: 2.5rem 0;
   }
 
   form {
@@ -31,7 +33,9 @@ export const Container = styled.div`
   }
 `;
 
-export const LogoH1 = styled.h1``;
+export const MoveHomeLink = styled(Link)`
+  padding-bottom: 2rem;
+`;
 
 export const InputContainer = styled.div`
   display: flex;

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -49,11 +49,9 @@ const Login = () => {
 
   return (
     <S.Container>
-      <S.LogoH1>
-        <Link to={ROUTES.main}>
-          <img src={Mainlogo} alt='logo' />
-        </Link>
-      </S.LogoH1>
+      <S.MoveHomeLink to={ROUTES.main}>
+        <img src={Mainlogo} alt='logo' />
+      </S.MoveHomeLink>
       <Title size='semiLarge'>로그인</Title>
       <form onSubmit={handleSubmit(onSubmit)}>
         <Controller


### PR DESCRIPTION
### 구현내용

로그인 화면 세로 중간정렬 수정

### 연관이슈

close #282 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 로그인 페이지의 레이아웃이 개선되어, 컨텐츠가 화면 중앙에 정렬되고 로고 이미지의 여백이 조정되었습니다.
- **Refactor**
  - 로고 이미지를 메인 페이지로 이동하는 하나의 스타일링된 링크로 통합하여 구조가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->