### PR TITLE
"지원하기" 페이지에 자잘한 기타 기능들 추가 및 자잘한 경로 에러 수정( issue #293, #299 )

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,8 +1,8 @@
 import { ApiVerifyNickname, VerifyEmail } from '../models/auth';
 import { httpClient } from './http.api';
-import { registerFormValues } from '../pages/register/Register';
-import { changePasswordFormValues } from '../pages/changePassword/ChangePassword';
 import { loginFormValues } from '../pages/login/Login';
+import { registerFormValues } from '../pages/user/register/Register';
+import { changePasswordFormValues } from '../pages/user/changePassword/ChangePassword';
 
 export const postVerificationEmail = async (email: string) => {
   try {

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -11,11 +11,19 @@ import loadingImg from '../../../assets/loadingImg.svg';
 import { useModal } from '../../../hooks/useModal';
 import Modal from '../modal/Modal';
 import { formatImgPath } from '../../../util/formatImgPath';
+<<<<<<< HEAD
 // import bell from '../../../assets/bell.svg';
 // import Notification from './Notification/Notification';
 // import bellLogined from '../../../assets/bellLogined.svg';
 // import { useEffect } from 'react';
 // import { testLiveAlarm } from '../../../api/alarm.api';
+=======
+import bell from '../../../assets/bell.svg';
+import Notification from './Notification/Notification';
+import bellLogined from '../../../assets/bellLogined.svg';
+import { useEffect } from 'react';
+import { testLiveAlarm } from '../../../api/alarm.api';
+>>>>>>> 0928e05 (refactor : 해결되지 않은 경로 에러 해결)
 import { useMyProfileInfo } from '../../../hooks/user/useMyInfo';
 import { ROUTES } from '../../../constants/user/routes';
 

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -11,11 +11,11 @@ import loadingImg from '../../../assets/loadingImg.svg';
 import { useModal } from '../../../hooks/useModal';
 import Modal from '../modal/Modal';
 import { formatImgPath } from '../../../util/formatImgPath';
-import bell from '../../../assets/bell.svg';
-import Notification from './Notification/Notification';
-import bellLogined from '../../../assets/bellLogined.svg';
-import { useEffect } from 'react';
-import { testLiveAlarm } from '../../../api/alarm.api';
+// import bell from '../../../assets/bell.svg';
+// import Notification from './Notification/Notification';
+// import bellLogined from '../../../assets/bellLogined.svg';
+// import { useEffect } from 'react';
+// import { testLiveAlarm } from '../../../api/alarm.api';
 import { useMyProfileInfo } from '../../../hooks/user/useMyInfo';
 import { ROUTES } from '../../../constants/user/routes';
 

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -14,7 +14,6 @@ import { formatImgPath } from '../../../util/formatImgPath';
 import bell from '../../../assets/bell.svg';
 import Notification from './Notification/Notification';
 import bellLogined from '../../../assets/bellLogined.svg';
-import useNotification from '../../../hooks/useNotification';
 import { useEffect } from 'react';
 import { testLiveAlarm } from '../../../api/alarm.api';
 import { useMyProfileInfo } from '../../../hooks/user/useMyInfo';

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -11,19 +11,11 @@ import loadingImg from '../../../assets/loadingImg.svg';
 import { useModal } from '../../../hooks/useModal';
 import Modal from '../modal/Modal';
 import { formatImgPath } from '../../../util/formatImgPath';
-<<<<<<< HEAD
 // import bell from '../../../assets/bell.svg';
 // import Notification from './Notification/Notification';
 // import bellLogined from '../../../assets/bellLogined.svg';
 // import { useEffect } from 'react';
 // import { testLiveAlarm } from '../../../api/alarm.api';
-=======
-import bell from '../../../assets/bell.svg';
-import Notification from './Notification/Notification';
-import bellLogined from '../../../assets/bellLogined.svg';
-import { useEffect } from 'react';
-import { testLiveAlarm } from '../../../api/alarm.api';
->>>>>>> 0928e05 (refactor : 해결되지 않은 경로 에러 해결)
 import { useMyProfileInfo } from '../../../hooks/user/useMyInfo';
 import { ROUTES } from '../../../constants/user/routes';
 

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -8,12 +8,14 @@ import { ModalWrapper } from './ModalWrapper';
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onConfirm?: () => void;
 }
 
 const Modal = ({
   children,
   isOpen,
   onClose,
+  onConfirm,
 }: PropsWithChildren<ModalProps>) => {
   const modalRefs = useOutsideClick(() => handleClose());
   const [isFadingOut, setIsFadingOut] = useState(false);
@@ -24,7 +26,11 @@ const Modal = ({
 
   const handleAnimationEnd = () => {
     if (isFadingOut) {
-      onClose();
+      if (onConfirm) {
+        onConfirm();
+      } else {
+        onClose();
+      }
       setIsFadingOut(false);
     }
   };
@@ -33,7 +39,7 @@ const Modal = ({
 
   return createPortal(
     <ScrollPreventor>
-      <ModalWrapper isOpen={isOpen} onClose={onClose}>
+      <ModalWrapper isOpen={isOpen} onClose={onClose} onConfirm={onConfirm}>
         <ModalWrapper.Container
           $fadeOut={isFadingOut}
           onAnimationEnd={handleAnimationEnd}

--- a/src/components/common/modal/ModalWrapper.tsx
+++ b/src/components/common/modal/ModalWrapper.tsx
@@ -15,11 +15,13 @@ export const ModalWrapper = ({
       event.stopPropagation();
     }
   },
+  onConfirm = () => {},
   children,
 }: PropsWithChildren<Partial<ModalContextProps>>) => {
   const modalProps: ModalContextProps = {
     isOpen,
     onClose,
+    onConfirm,
   };
 
   return <ModalProvider value={modalProps}>{children}</ModalProvider>;

--- a/src/components/user/applyComponents/careersComponent/CareersComponent.styled.ts
+++ b/src/components/user/applyComponents/careersComponent/CareersComponent.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Button from '../../common/Button/Button';
+import Button from '../../../common/Button/Button';
 
 export const Container = styled.div`
   width: 100%;

--- a/src/components/user/applyComponents/careersComponent/CareersComponent.styled.ts
+++ b/src/components/user/applyComponents/careersComponent/CareersComponent.styled.ts
@@ -17,11 +17,15 @@ export const CareerContainer = styled.div`
   }
 `;
 
+export const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
 export const AddButton = styled(Button)`
   width: 50px;
   height: 30px;
   font-size: 13px;
   padding: 10px;
-  cursor: pointer;
   border: 1px solid ${({ theme }) => theme.color.border};
 `;

--- a/src/components/user/applyComponents/careersComponent/CareersComponent.tsx
+++ b/src/components/user/applyComponents/careersComponent/CareersComponent.tsx
@@ -29,22 +29,24 @@ const CareersComponent = ({ control }: CareersComponentProps) => {
           ))}
         </S.CareerContainer>
       ))}
-      <S.AddButton
-        size='primary'
-        schema='primary'
-        radius='primary'
-        type='button'
-        onClick={() =>
-          appendCareers({
-            name: '',
-            periodStart: '',
-            periodEnd: '',
-            role: '',
-          })
-        }
-      >
-        추가
-      </S.AddButton>
+      <S.ButtonWrapper>
+        <S.AddButton
+          size='primary'
+          schema='primary'
+          radius='primary'
+          type='button'
+          onClick={() =>
+            appendCareers({
+              name: '',
+              periodStart: '',
+              periodEnd: '',
+              role: '',
+            })
+          }
+        >
+          추가
+        </S.AddButton>
+      </S.ButtonWrapper>
     </S.Container>
   );
 };

--- a/src/components/user/comment/commentComponent/CommentComponentLayout.tsx
+++ b/src/components/user/comment/commentComponent/CommentComponentLayout.tsx
@@ -1,13 +1,13 @@
 import * as S from './CommentComponentLayout.styled';
 import DropDown from '../../../common/dropDown/DropDown';
 import DropDownItem from '../DropDownItem';
-import dropdownButton from '../../../assets/dropdownButton.svg';
 import useComment from '../../../../hooks/user/CommentHooks/useComment';
 import ReplyComponent from '../replyComponent/ReplyComponent';
-import ArrowDown from '../../../assets/ArrowDown.svg';
-import ArrowUp from '../../../assets/ArrowUp.svg';
+import ArrowUp from '../../../../assets/ArrowUp.svg';
 import CommentComponent from './commentComponent/CommentComponent';
 import { CommentType } from '../../../../models/comment';
+import dropdownButton from '../../../../assets/dropdownButton.svg';
+import ArrowDown from '../../../../assets/ArrowDown.svg';
 
 interface CommentLayoutProps {
   projectId: number;

--- a/src/components/user/comment/commentComponent/CommentComponentLayout.tsx
+++ b/src/components/user/comment/commentComponent/CommentComponentLayout.tsx
@@ -1,13 +1,20 @@
 import * as S from './CommentComponentLayout.styled';
 import DropDown from '../../../common/dropDown/DropDown';
 import DropDownItem from '../DropDownItem';
+<<<<<<< HEAD
+=======
+import dropdownButton from '../../../assets/dropdownButton.svg';
+>>>>>>> 0928e05 (refactor : 해결되지 않은 경로 에러 해결)
 import useComment from '../../../../hooks/user/CommentHooks/useComment';
 import ReplyComponent from '../replyComponent/ReplyComponent';
 import ArrowUp from '../../../../assets/ArrowUp.svg';
 import CommentComponent from './commentComponent/CommentComponent';
 import { CommentType } from '../../../../models/comment';
+<<<<<<< HEAD
 import dropdownButton from '../../../../assets/dropdownButton.svg';
 import ArrowDown from '../../../../assets/ArrowDown.svg';
+=======
+>>>>>>> 0928e05 (refactor : 해결되지 않은 경로 에러 해결)
 
 interface CommentLayoutProps {
   projectId: number;

--- a/src/components/user/comment/commentComponent/CommentComponentLayout.tsx
+++ b/src/components/user/comment/commentComponent/CommentComponentLayout.tsx
@@ -1,20 +1,13 @@
 import * as S from './CommentComponentLayout.styled';
 import DropDown from '../../../common/dropDown/DropDown';
 import DropDownItem from '../DropDownItem';
-<<<<<<< HEAD
-=======
-import dropdownButton from '../../../assets/dropdownButton.svg';
->>>>>>> 0928e05 (refactor : 해결되지 않은 경로 에러 해결)
 import useComment from '../../../../hooks/user/CommentHooks/useComment';
 import ReplyComponent from '../replyComponent/ReplyComponent';
 import ArrowUp from '../../../../assets/ArrowUp.svg';
 import CommentComponent from './commentComponent/CommentComponent';
 import { CommentType } from '../../../../models/comment';
-<<<<<<< HEAD
 import dropdownButton from '../../../../assets/dropdownButton.svg';
 import ArrowDown from '../../../../assets/ArrowDown.svg';
-=======
->>>>>>> 0928e05 (refactor : 해결되지 않은 경로 에러 해결)
 
 interface CommentLayoutProps {
   projectId: number;

--- a/src/components/user/comment/commentComponent/CommentComponentLayout.tsx
+++ b/src/components/user/comment/commentComponent/CommentComponentLayout.tsx
@@ -1,13 +1,13 @@
 import * as S from './CommentComponentLayout.styled';
 import DropDown from '../../../common/dropDown/DropDown';
 import DropDownItem from '../DropDownItem';
-import { CommentType } from '../../../../models/comment';
 import dropdownButton from '../../../assets/dropdownButton.svg';
 import useComment from '../../../../hooks/user/CommentHooks/useComment';
 import ReplyComponent from '../replyComponent/ReplyComponent';
 import ArrowDown from '../../../assets/ArrowDown.svg';
 import ArrowUp from '../../../assets/ArrowUp.svg';
 import CommentComponent from './commentComponent/CommentComponent';
+import { CommentType } from '../../../../models/comment';
 
 interface CommentLayoutProps {
   projectId: number;

--- a/src/components/user/comment/commentComponent/commentComponent/CommentComponent.tsx
+++ b/src/components/user/comment/commentComponent/commentComponent/CommentComponent.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction } from 'react';
 import * as S from './CommentComponent.styled';
-import chat from '../../../../assets/chat.svg';
+import chat from '../../../../../assets/chat.svg';
 import { Link } from 'react-router-dom';
 import CommentInput from '../../commentInput/CommentInput';
 import { CommentType } from '../../../../../models/comment';

--- a/src/components/user/comment/commentComponent/commentComponent/CommentComponent.tsx
+++ b/src/components/user/comment/commentComponent/commentComponent/CommentComponent.tsx
@@ -1,11 +1,11 @@
 import { Dispatch, SetStateAction } from 'react';
 import * as S from './CommentComponent.styled';
-import Avatar from '../../../common/avatar/Avatar';
-import { CommentType } from '../../../../models/comment';
 import chat from '../../../../assets/chat.svg';
 import { Link } from 'react-router-dom';
-import { ROUTES } from '../../../../constants/routes';
 import CommentInput from '../../commentInput/CommentInput';
+import { CommentType } from '../../../../../models/comment';
+import { ROUTES } from '../../../../../constants/user/routes';
+import Avatar from '../../../../common/avatar/Avatar';
 
 interface CommentComponentProps {
   item: CommentType;

--- a/src/components/user/comment/commentInput/CommentInput.styled.ts
+++ b/src/components/user/comment/commentInput/CommentInput.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Button from '../../common/Button/Button';
+import Button from '../../../common/Button/Button';
 
 export const InputContainer = styled.div`
   display: flex;

--- a/src/components/user/comment/commentInput/CommentInput.tsx
+++ b/src/components/user/comment/commentInput/CommentInput.tsx
@@ -2,7 +2,7 @@ import * as S from './CommentInput.styled';
 import { Dispatch, SetStateAction, useEffect } from 'react';
 import { useMyProfileInfo } from '../../../../hooks/user/useMyInfo';
 import { formatImgPath } from '../../../../util/formatImgPath';
-import DefaultImg from '../../../assets/defaultImg.png';
+import DefaultImg from '../../../../assets/defaultImg.png';
 import Avatar from '../../../common/avatar/Avatar';
 import { useForm } from 'react-hook-form';
 import useInputFocus from '../../../../hooks/user/useInputFocus';

--- a/src/components/user/comment/replyComponent/ReplyComponent.tsx
+++ b/src/components/user/comment/replyComponent/ReplyComponent.tsx
@@ -1,15 +1,15 @@
 import Avatar from '../../../common/avatar/Avatar';
 import * as S from './ReplyComponent.styled';
-import DefaultImg from '../../../assets/defaultImg.png';
+import DefaultImg from '../../../../assets/defaultImg.png';
 import useComment from '../../../../hooks/user/CommentHooks/useComment';
 import DropDown from '../../../common/dropDown/DropDown';
 import DropDownItem from '../DropDownItem';
-import dropdownButton from '../../../assets/dropdownButton.svg';
 import CommentInput from '../commentInput/CommentInput';
 import useGetReply from '../../../../hooks/user/CommentHooks/useGetReply';
 import LoadingSpinner from '../../../common/loadingSpinner/LoadingSpinner';
 import { Link } from 'react-router-dom';
 import { ROUTES } from '../../../../constants/user/routes';
+import dropdownButton from '../../../../assets/dropdownButton.svg';
 
 interface ReplyComponentProps {
   projectId: number;

--- a/src/components/user/evaluation/EvaluationContent.styled.ts
+++ b/src/components/user/evaluation/EvaluationContent.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Button from '../common/Button/Button';
+import Button from '../../common/Button/Button';
 
 export const Container = styled.div`
   display: flex;

--- a/src/components/user/home/banner/Banner.tsx
+++ b/src/components/user/home/banner/Banner.tsx
@@ -1,5 +1,5 @@
 import * as S from './Banner.styled';
-import banner from '../../../assets/banner.svg';
+import banner from '../../../../assets/banner.svg';
 
 export default function Banner() {
   return (

--- a/src/components/user/home/projectCardLists/cardList/CardList.tsx
+++ b/src/components/user/home/projectCardLists/cardList/CardList.tsx
@@ -1,10 +1,10 @@
 import PositionButton from '../../../../common/positionButton/PositionButton';
 import * as S from './CardList.styled';
 import beginner from '../../../../assets/beginner.svg';
-import Avatar from '../../../../common/avatar/Avatar';
 import { EyeIcon } from '@heroicons/react/24/outline';
 import type { ProjectList } from '../../../../../models/mainProjectLists';
 import { formatDate } from '../../../../../util/formatDate';
+import Avatar from '../../../../common/avatar/Avatar';
 
 interface CardListProps {
   list: ProjectList;
@@ -28,6 +28,7 @@ export default function CardList({ list }: CardListProps) {
               <PositionButton
                 position={tag.name}
                 key={`cardListPosition-${tag.id}`}
+                fontSize
               />
             ))}
           {list.positions.length > listPositionTag.length && (

--- a/src/components/user/home/projectCardLists/cardList/CardList.tsx
+++ b/src/components/user/home/projectCardLists/cardList/CardList.tsx
@@ -1,10 +1,10 @@
 import PositionButton from '../../../../common/positionButton/PositionButton';
 import * as S from './CardList.styled';
-import beginner from '../../../../assets/beginner.svg';
 import { EyeIcon } from '@heroicons/react/24/outline';
 import type { ProjectList } from '../../../../../models/mainProjectLists';
 import { formatDate } from '../../../../../util/formatDate';
 import Avatar from '../../../../common/avatar/Avatar';
+import beginner from '../../../../../assets/beginner.svg';
 
 interface CardListProps {
   list: ProjectList;

--- a/src/components/user/home/searchFiltering/filteringContents/FilteringContents.tsx
+++ b/src/components/user/home/searchFiltering/filteringContents/FilteringContents.tsx
@@ -1,6 +1,5 @@
 import Filtering from './filtering/Filtering';
 import * as S from './FilteringContents.styled';
-import beginner from '../../../../assets/beginner.svg';
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
 import SkillTagBox from '../../../../common/skillTagBox/SkillTagBox';
 import React, { useState } from 'react';
@@ -8,6 +7,7 @@ import { useSearchFilteringSkillTag } from '../../../../../hooks/user/useSearchF
 import { useOutsideClick } from '../../../../../hooks/user/useOutsideClick';
 import { useSaveSearchFiltering } from '../../../../../hooks/user/useSaveSearchFiltering';
 import { SEARCH_FILTERING_DEFAULT_VALUE } from '../../../../../constants/user/homeConstants';
+import beginner from '../../../../../assets/beginner.svg';
 
 export default function FilteringContents() {
   const { positionTagsData, methodTagsData } = useSearchFilteringSkillTag();

--- a/src/components/user/home/searchFiltering/filteringContents/filtering/Filtering.tsx
+++ b/src/components/user/home/searchFiltering/filteringContents/filtering/Filtering.tsx
@@ -1,11 +1,10 @@
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
 import * as S from './Filtering.styled';
 import { useEffect, useState } from 'react';
-import type { MethodTag, PositionTag } from '../../../../../models/tags';
-import { useOutsideClick } from '../../../../../hooks/useOutsideClick';
-import { useSaveSearchFiltering } from '../../../../../hooks/useSaveSearchFiltering';
-import { SEARCH_FILTERING_DEFAULT_VALUE } from '../../../../../constants/homeConstants';
-
+import { useSaveSearchFiltering } from '../../../../../../hooks/user/useSaveSearchFiltering';
+import { MethodTag, PositionTag } from '../../../../../../models/tags';
+import { SEARCH_FILTERING_DEFAULT_VALUE } from '../../../../../../constants/user/homeConstants';
+import { useOutsideClick } from '../../../../../../hooks/user/useOutsideClick';
 interface FilteringProps {
   selects: PositionTag[] | MethodTag[];
   defaultValue: string;

--- a/src/components/user/manageProjects/passNonPassList/SendResultButton.styled.ts
+++ b/src/components/user/manageProjects/passNonPassList/SendResultButton.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Button from '../../common/Button/Button';
+import Button from '../../../common/Button/Button';
 
 export const Wrapper = styled.div`
   width: 100%;

--- a/src/components/user/mypage/ContentTab.tsx
+++ b/src/components/user/mypage/ContentTab.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import * as S from './ContentTab.styled';
 import { Link, Outlet, useLocation } from 'react-router-dom';
-import { ROUTES } from '../../constants/routes';
 import ScrollWrapper from './ScrollWrapper';
 import MovedInquiredLink from '../customerService/MoveInquiredLink';
+import { ROUTES } from '../../../constants/user/routes';
 
 interface Filter {
   title: string;

--- a/src/components/user/mypage/activityLog/inquiries/inquiry/Inquiry.tsx
+++ b/src/components/user/mypage/activityLog/inquiries/inquiry/Inquiry.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import type { MyInquiries } from '../../../../../models/activityLog';
 import * as S from './Inquiry.styled';
-import { My_INQUIRIES_MESSAGE } from '../../../../../constants/customerService';
+import { MyInquiries } from '../../../../../../models/activityLog';
+import { My_INQUIRIES_MESSAGE } from '../../../../../../constants/user/customerService';
 
 interface InquiryProps {
   list: MyInquiries;

--- a/src/components/user/mypage/joinedProject/Project.tsx
+++ b/src/components/user/mypage/joinedProject/Project.tsx
@@ -1,7 +1,7 @@
 import * as S from './Project.styled';
-import BeginnerIcon from '../../../assets/beginner.svg';
 import { EllipsisHorizontalIcon } from '@heroicons/react/24/outline';
 import { JoinedProject } from '../../../../models/userProject';
+import beginner from '../../../../assets/beginner.svg';
 
 interface ProjectProps {
   project: JoinedProject;
@@ -22,11 +22,7 @@ const Project = ({ project }: ProjectProps) => {
       <S.Member>
         <S.Wrapper>
           <S.Beginner>
-            {project.isBeginner ? (
-              <img src={BeginnerIcon} alt='beginner' />
-            ) : (
-              ''
-            )}
+            {project.isBeginner ? <img src={beginner} alt='beginner' /> : ''}
           </S.Beginner>
           <span>{project.totalMember}명</span>
         </S.Wrapper>

--- a/src/components/user/mypage/myProfile/profile/Profile.tsx
+++ b/src/components/user/mypage/myProfile/profile/Profile.tsx
@@ -1,5 +1,5 @@
 import * as S from './Profile.styled';
-import BeginnerIcon from '../../../../assets/beginner.svg';
+import BeginnerIcon from '../../../../../assets/beginner.svg';
 import 'chart.js/auto';
 import { ChartOptions } from 'chart.js';
 import { Link, useOutletContext } from 'react-router-dom';

--- a/src/components/user/projectFormComponents/projectInformationInput/positionComponent/PositionComponent.styled.ts
+++ b/src/components/user/projectFormComponents/projectInformationInput/positionComponent/PositionComponent.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import PositionButton from '../../../common/positionButton/PositionButton';
+import PositionButton from '../../../../common/positionButton/PositionButton';
 
 export const Container = styled.div``;
 

--- a/src/components/user/projectFormComponents/projectInformationInput/positionComponent/PositionComponent.tsx
+++ b/src/components/user/projectFormComponents/projectInformationInput/positionComponent/PositionComponent.tsx
@@ -36,7 +36,9 @@ const MozipCategoryComponent = ({
             <S.PositionButtonFeat
               position={position.name}
               isSelected={isSelected}
-              onClick={(e) => handleClick(e, idx + 1)}
+              onClick={(e: React.MouseEvent<HTMLElement>) =>
+                handleClick(e, idx + 1)
+              }
               key={idx + 1}
               isHover={true}
               fontSize={true}

--- a/src/components/user/projectFormComponents/projectInformationText/ProjectInformation.tsx
+++ b/src/components/user/projectFormComponents/projectInformationText/ProjectInformation.tsx
@@ -5,7 +5,7 @@ import {
 } from '../../../../models/projectDetail';
 import { formatDate } from '../../../../util/formatDate';
 import * as S from './ProjectInformation.styled';
-import beginner from '/src/assets/beginner.svg';
+import beginner from '../../../../assets/beginner.svg';
 
 interface ProjectInformationProps {
   data: ProjectDetailPlusExtended;

--- a/src/components/user/projectFormComponents/stepComponent/StepComponent.tsx
+++ b/src/components/user/projectFormComponents/stepComponent/StepComponent.tsx
@@ -1,22 +1,16 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import React from 'react';
 import * as S from './StepComponent.styled';
 import { StepProp } from '../../../../hooks/user/ProjectHooks/useMultiStepForm';
 
 type StepComponentProps = {
   steps: StepProp[];
   currentStepIndex: number;
-  setCurrentStepIndex: Dispatch<SetStateAction<number>>;
 };
 
 const StepComponent: React.FC<StepComponentProps> = ({
   steps,
   currentStepIndex,
-  setCurrentStepIndex,
 }) => {
-  const handleClick = (index: number) => {
-    setCurrentStepIndex(index);
-  };
-
   return (
     <S.Container>
       <S.Line />
@@ -25,10 +19,7 @@ const StepComponent: React.FC<StepComponentProps> = ({
 
         return (
           <S.StepWrapper key={index}>
-            <S.Circle
-              isActive={isActive}
-              onClick={() => handleClick(index)}
-            ></S.Circle>
+            <S.Circle isActive={isActive}></S.Circle>
             <S.Label>{step.title}</S.Label>
           </S.StepWrapper>
         );

--- a/src/components/user/userPage/userProfile/UserProfile.tsx
+++ b/src/components/user/userPage/userProfile/UserProfile.tsx
@@ -1,4 +1,4 @@
-import * as S from '../../../mypage/myProfile/MyProfile.styled';
+import * as S from '../../';
 import BeginnerIcon from '../../../assets/beginner.svg';
 import { useParams } from 'react-router-dom';
 import { useUserProfileInfo } from '../../../../hooks/user/useUserInfo';

--- a/src/constants/sidebarItems.tsx
+++ b/src/constants/sidebarItems.tsx
@@ -1,9 +1,9 @@
-import { ROUTES } from './routes';
 import {
   UserGroupIcon,
   PencilSquareIcon,
   UserPlusIcon,
 } from '@heroicons/react/24/outline';
+import { ROUTES } from './user/routes';
 
 export const applicantsMenuItems = (projectId: number, isDone?: boolean) => {
   return [

--- a/src/constants/user/modalMessage.ts
+++ b/src/constants/user/modalMessage.ts
@@ -24,4 +24,5 @@ export const MODAL_MESSAGE = {
   applyProjectSuccess: '해당 공고에 지원을 완료 되었습니다.',
   applyProjectFail: '해당 공고에 지원을 실패 되었습니다.',
   projectDetailFail: '해당 공고가 존재하지 않습니다.',
+  alreadyApply: '이미 참여한/지원하신 공고 입니다.',
 } as const;

--- a/src/context/ModalContext.tsx
+++ b/src/context/ModalContext.tsx
@@ -3,11 +3,13 @@ import { createContext } from 'react';
 export interface ModalContextProps {
   isOpen: boolean;
   onClose: (event?: React.SyntheticEvent) => void;
+  onConfirm: (event?: React.SyntheticEvent) => void;
 }
 
 const defaultContext: Partial<ModalContextProps> = {
   isOpen: false,
   onClose: () => {},
+  onConfirm: () => {},
 };
 
 export const ModalContext =

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -3,16 +3,27 @@ import { useCallback, useState } from 'react';
 export const useModal = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [message, setMessage] = useState<string>('');
+  const [onConfirm, setOnConfirm] = useState<(() => void) | null>(null);
 
-  const handleModalOpen = useCallback((newMessage: string) => {
-    setMessage(newMessage);
-    setIsOpen(true);
-  }, []);
+  const handleModalOpen = useCallback(
+    (newMessage: string, callback?: () => void) => {
+      setMessage(newMessage);
+      setIsOpen(true);
+      setOnConfirm(() => callback ?? null);
+    },
+    []
+  );
 
   const handleModalClose = useCallback(() => {
     setMessage('');
     setIsOpen(false);
+    setOnConfirm(null);
   }, []);
+
+  const handleConfirm = useCallback(() => {
+    if (onConfirm) onConfirm();
+    handleModalClose();
+  }, [onConfirm, handleModalClose]);
 
   const handleOpenReportModal = () => {
     setIsOpen(true);
@@ -30,5 +41,6 @@ export const useModal = () => {
     handleModalOpen,
     handleOpenReportModal,
     handleCloseReportModal,
+    handleConfirm,
   };
 };

--- a/src/models/createProject.ts
+++ b/src/models/createProject.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { createProjectScheme } from '../constants/projectConstants';
+import { createProjectScheme } from '../constants/user/projectConstants';
 
 export type CreateProjectFormValues = z.infer<typeof createProjectScheme>;
 

--- a/src/models/joinProject.ts
+++ b/src/models/joinProject.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { ApplyScheme } from '../constants/projectConstants';
+import { ApplyScheme } from '../constants/user/projectConstants';
 
 export type ApplySchemeType = z.infer<typeof ApplyScheme>;
 

--- a/src/models/projectDetail.ts
+++ b/src/models/projectDetail.ts
@@ -33,6 +33,8 @@ export interface ProjectDetailPlusExtended extends ProjectDetailPlus {
   methodType: MethodTag;
   positions: PositionTag[];
   skills: SkillTag[];
+  applicantIds: number[];
+  acceptedIds: number[];
 }
 
 export interface dataPlus extends ApiCommonType {

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -2,17 +2,20 @@ import { Link } from 'react-router-dom';
 import * as S from './Login.styled';
 import Mainlogo from '../../assets/mainlogo.svg';
 import { EnvelopeIcon, KeyIcon } from '@heroicons/react/24/outline';
-import InputText from '../../components/auth/InputText';
 import Title from '../../components/common/title/Title';
 import { z } from 'zod';
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Button from '../../components/common/Button/Button';
-import { ERROR_MESSAGES, OAUTH_PROVIDERS } from '../../constants/authConstants';
 import { useAuth } from '../../hooks/useAuth';
-import { ROUTES } from '../../constants/routes';
 import { useModal } from '../../hooks/useModal';
 import Modal from '../../components/common/modal/Modal';
+import {
+  ERROR_MESSAGES,
+  OAUTH_PROVIDERS,
+} from '../../constants/user/authConstants';
+import InputText from '../../components/user/auth/InputText';
+import { ROUTES } from '../../constants/user/routes';
 
 const loginSchema = z.object({
   email: z

--- a/src/pages/login/LoginSuccess.tsx
+++ b/src/pages/login/LoginSuccess.tsx
@@ -1,12 +1,12 @@
 import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import useAuthStore from '../../store/authStore';
-import { ROUTES } from '../../constants/routes';
 import * as S from './Login.styled';
 import { Spinner } from '../../components/common/loadingSpinner/LoadingSpinner.styled';
 import Modal from '../../components/common/modal/Modal';
 import { useModal } from '../../hooks/useModal';
-import { AUTH_MESSAGE } from '../../constants/authConstants';
+import { ROUTES } from '../../constants/user/routes';
+import { AUTH_MESSAGE } from '../../constants/user/authConstants';
 
 function LoginSuccess() {
   const [searchParams] = useSearchParams();

--- a/src/pages/user/apply/Apply.styled.ts
+++ b/src/pages/user/apply/Apply.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Button from '../../components/common/Button/Button';
+import Button from '../../../components/common/Button/Button';
 
 export const Container = styled.div`
   max-width: 100%;

--- a/src/pages/user/apply/ApplyStep.styled.ts
+++ b/src/pages/user/apply/ApplyStep.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Button from '../../components/common/Button/Button';
+import Button from '../../../components/common/Button/Button';
 
 export const Container = styled.div`
   max-width: 100%;

--- a/src/pages/user/apply/ApplyStep.styled.ts
+++ b/src/pages/user/apply/ApplyStep.styled.ts
@@ -46,7 +46,8 @@ export const StepContainer = styled.div`
 
 export const StepButton = styled.div`
   display: flex;
-  justify-content: right;
+  justify-content: left;
+  padding-top: 20px;
   gap: 20px;
 `;
 

--- a/src/pages/user/apply/ApplyStep.tsx
+++ b/src/pages/user/apply/ApplyStep.tsx
@@ -47,11 +47,13 @@ const Apply = () => {
   });
 
   useEffect(() => {
+    if (!userData) {
+      return handleModalOpen(MODAL_MESSAGE.isNotLoggedIn, () => navigate(-1));
+    }
     if (
-      userData &&
-      (userData?.id !== projectData?.user.id ||
-        !projectData?.acceptedIds.includes(userData?.id) ||
-        !projectData?.applicantIds.includes(userData?.id))
+      userData?.id === projectData?.user.id ||
+      projectData?.acceptedIds.includes(userData?.id) ||
+      projectData?.applicantIds.includes(userData?.id)
     ) {
       handleModalOpen(MODAL_MESSAGE.alreadyApply, () => navigate(-1));
     }

--- a/src/pages/user/apply/ApplyStep.tsx
+++ b/src/pages/user/apply/ApplyStep.tsx
@@ -2,7 +2,7 @@ import * as S from './ApplyStep.styled';
 
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useModal } from '../../../hooks/useModal';
 import useGetProjectData from '../../../hooks/user/useGetProjectData';
 import useApplyProject from '../../../hooks/user/ProjectHooks/useApplyProject';
@@ -19,14 +19,17 @@ import LoadingSpinner from '../../../components/common/loadingSpinner/LoadingSpi
 import { formatDate } from '../../../util/formatDate';
 import StepComponent from '../../../components/user/projectFormComponents/stepComponent/StepComponent';
 import Button from '../../../components/common/Button/Button';
+import { MODAL_MESSAGE } from '../../../constants/user/modalMessage';
 
 const Apply = () => {
   const { projectId } = useParams();
   const id = Number(projectId);
-  const { isOpen, handleModalOpen, handleModalClose, message } = useModal();
+  const navigate = useNavigate();
+  const { isOpen, handleModalOpen, handleModalClose, handleConfirm, message } =
+    useModal();
   const { data: projectData, isLoading, isFetching } = useGetProjectData(id);
   const { applyProject } = useApplyProject({ id, handleModalOpen });
-  const userEmail = useAuthStore((state) => state.userData?.email);
+  const userData = useAuthStore((state) => state.userData);
   const {
     handleSubmit: onSubmitHandler,
     formState: { errors },
@@ -42,6 +45,17 @@ const Apply = () => {
       careers: [],
     },
   });
+
+  useEffect(() => {
+    if (
+      userData &&
+      (userData?.id !== projectData?.user.id ||
+        !projectData?.acceptedIds.includes(userData?.id) ||
+        !projectData?.applicantIds.includes(userData?.id))
+    ) {
+      handleModalOpen(MODAL_MESSAGE.alreadyApply, () => navigate(-1));
+    }
+  }, [userData, projectData, navigate, handleModalOpen]);
 
   const stepFields: (keyof ApplySchemeType)[][] = [
     ['email'],
@@ -86,8 +100,8 @@ const Apply = () => {
   ];
 
   useEffect(() => {
-    if (userEmail) setValue('email', userEmail);
-  }, [userEmail, setValue]);
+    if (userData?.email) setValue('email', userData.email);
+  }, [userData, setValue]);
 
   const {
     currentStepIndex,
@@ -119,7 +133,11 @@ const Apply = () => {
 
   if (!projectData) {
     return (
-      <Modal isOpen={isOpen} onClose={handleModalClose}>
+      <Modal
+        isOpen={isOpen}
+        onClose={handleModalClose}
+        onConfirm={handleConfirm}
+      >
         {message}
       </Modal>
     );
@@ -183,7 +201,11 @@ const Apply = () => {
         )}
       </form>
 
-      <Modal isOpen={isOpen} onClose={handleModalClose}>
+      <Modal
+        isOpen={isOpen}
+        onClose={handleModalClose}
+        onConfirm={handleConfirm}
+      >
         {message}
       </Modal>
     </S.Container>

--- a/src/pages/user/apply/ApplyStep.tsx
+++ b/src/pages/user/apply/ApplyStep.tsx
@@ -112,7 +112,6 @@ const Apply = () => {
     isLastStep,
     prev,
     next,
-    setCurrentStepIndex,
   } = useMultiStepForm(stepList);
 
   const handleNextStep = async () => {
@@ -155,11 +154,7 @@ const Apply = () => {
         projectData?.recruitmentEndDate
       )}`}</S.Dates>
 
-      <StepComponent
-        steps={stepList}
-        currentStepIndex={currentStepIndex}
-        setCurrentStepIndex={setCurrentStepIndex}
-      />
+      <StepComponent steps={stepList} currentStepIndex={currentStepIndex} />
 
       <form onSubmit={onSubmitHandler(handleSubmit)}>
         <S.StepWrapper>

--- a/src/pages/user/manage/myProjectParticipantsPass/MyProjectVolunteersPass.tsx
+++ b/src/pages/user/manage/myProjectParticipantsPass/MyProjectVolunteersPass.tsx
@@ -1,6 +1,6 @@
 import * as S from './MyProjectVolunteersPass.styled';
 import { useParams } from 'react-router-dom';
-import MainLogo from '../../../assets/mainlogo.svg';
+import MainLogo from '../../../../assets/mainlogo.svg';
 import { Suspense, useMemo } from 'react';
 import useGetProjectData from '../../../../hooks/user/useGetProjectData';
 import { usePassNonPassList } from '../../../../hooks/user/usePassNonPassList';

--- a/src/pages/user/manage/myProjectVolunteer/MyProjectVolunteer.tsx
+++ b/src/pages/user/manage/myProjectVolunteer/MyProjectVolunteer.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom';
 import * as S from './MyProjectVolunteer.styled';
-import MainLogo from '../../../assets/mainlogo.svg';
+import MainLogo from '../../../../assets/mainlogo.svg';
 import { useMemo } from 'react';
 import useGetProjectData from '../../../../hooks/user/useGetProjectData';
 import { useModal } from '../../../../hooks/useModal';

--- a/src/pages/user/mypage/MyPage.tsx
+++ b/src/pages/user/mypage/MyPage.tsx
@@ -6,7 +6,7 @@ import {
   PencilSquareIcon,
   BellIcon,
 } from '@heroicons/react/24/outline';
-import loadingImg from '../../assets/loadingImg.svg';
+import loadingImg from '../../../assets/loadingImg.svg';
 import { ROUTES } from '../../../constants/user/routes';
 import { useMyProfileInfo } from '../../../hooks/user/useMyInfo';
 import Sidebar from '../../../components/common/sidebar/Sidebar';

--- a/src/pages/user/projectDetail/ProjectDetail.styled.ts
+++ b/src/pages/user/projectDetail/ProjectDetail.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Button from '../../components/common/Button/Button';
+import Button from '../../../components/common/Button/Button';
 
 export const Container = styled.div`
   width: 100%;

--- a/src/pages/user/projectDetail/ProjectDetail.tsx
+++ b/src/pages/user/projectDetail/ProjectDetail.tsx
@@ -41,6 +41,14 @@ const ProjectDetail = () => {
     );
   }
 
+  if (!userData) {
+    return (
+      <Modal isOpen={isOpen} onClose={handleModalClose}>
+        {message}
+      </Modal>
+    );
+  }
+
   const handleApplyClick = () => {
     navigate(`${ROUTES.apply}/${id}`);
   };
@@ -49,6 +57,9 @@ const ProjectDetail = () => {
     const userId = data.user.id;
     navigate(`/user/${userId}`);
   };
+
+  console.log(data);
+  console.log(userData.id);
 
   return (
     <S.Container>
@@ -80,7 +91,9 @@ const ProjectDetail = () => {
           </S.ProjectDescription>
         </S.Content>
         <S.ApplyButtonContainer>
-          {userData?.id !== data.user.id ? (
+          {userData.id !== data.user.id &&
+          !data.acceptedIds.includes(userData.id) &&
+          !data.applicantIds.includes(userData.id) ? (
             <Button
               size='primary'
               schema='primary'
@@ -95,7 +108,7 @@ const ProjectDetail = () => {
         <CommentLayout
           projectId={data.id}
           createrId={data.user.id}
-          loginUserId={userData?.id}
+          loginUserId={userData.id}
         />
       </S.Wrapper>
     </S.Container>

--- a/src/pages/user/register/Register.tsx
+++ b/src/pages/user/register/Register.tsx
@@ -1,6 +1,6 @@
 import * as S from '../../login/Login.styled';
 import { Link } from 'react-router-dom';
-import Mainlogo from '../../assets/mainlogo.svg';
+import Mainlogo from '../../../assets/mainlogo.svg';
 import { z } from 'zod';
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';

--- a/src/pages/user/userpage/UserPage.tsx
+++ b/src/pages/user/userpage/UserPage.tsx
@@ -1,7 +1,7 @@
 import { Outlet, useParams } from 'react-router-dom';
 import * as S from '../mypage/MyPage.styled';
 import { DocumentTextIcon, UserIcon } from '@heroicons/react/24/outline';
-import loadingImg from '../../assets/loadingImg.svg';
+import loadingImg from '../../../assets/loadingImg.svg';
 import { ROUTES } from '../../../constants/user/routes';
 import { useUserProfileInfo } from '../../../hooks/user/useUserInfo';
 import Sidebar from '../../../components/common/sidebar/Sidebar';


### PR DESCRIPTION
### 구현내용

- 자잘한 경로 에러 수정
- 참여한/지원한 사용자는 공고 상세 페이지에서 "프로젝트 함께하기" 버튼 제거
- 모달 종료 시 콜백 함수를 실행할 수 있도록 수정
- 참여한/지원한 사용자가 "지원하기 페이지"에 URL을 통해 접근 시 차단 적용
- "지원하기 페이지" 참여한/지원한 사용자 차단 로직 변경
- 각 단계 확인 컴포넌트에서 각 단계 클릭 시 이동하던 로직 제거

### 연관이슈
close #299 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 모달에 확인(Confirm) 콜백 기능이 추가되어, 사용자 상호작용 시 맞춤형 동작을 지원합니다.
  - 프로젝트 상세 정보에 지원자 및 합격자 ID 목록이 표시됩니다.
  - 이미 지원한 경우를 안내하는 모달 메시지가 추가되었습니다.

- **버그 수정**
  - 프로젝트 상세 및 지원 시, 이미 지원·합격·소유자인 경우 버튼 노출 및 이동 제한이 개선되었습니다.

- **리팩터**
  - 여러 컴포넌트 및 에셋의 import 경로가 정비되어 구조가 명확해졌습니다.
  - 불필요한 알림(벨) 기능이 비활성화되었습니다.
  - 프로젝트 단계 컴포넌트가 단순화되어 외부에서 단계 변경이 불가하도록 수정되었습니다.

- **스타일**
  - 버튼 및 일부 레이아웃 스타일이 조정되었습니다.

- **문서화**
  - 모달 메시지 및 일부 상수에 대한 설명이 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->