### PR TITLE
댓글 컴포넌트의 스타일 버그 해결

### DIFF
--- a/src/components/user/comment/CommentLayout.tsx
+++ b/src/components/user/comment/CommentLayout.tsx
@@ -3,10 +3,6 @@ import CommentInput from './commentInput/CommentInput';
 import LoadingSpinner from '../../common/loadingSpinner/LoadingSpinner';
 import useGetComment from '../../../hooks/user/CommentHooks/useGetComment';
 import CommentComponentLayout from './commentComponent/CommentComponentLayout';
-import Avatar from '../../common/avatar/Avatar';
-import { useMyProfileInfo } from '../../../hooks/user/useMyInfo';
-import { formatImgPath } from '../../../util/formatImgPath';
-import DefaultImg from '../../../assets/defaultImg.png';
 
 interface CommentLayoutProps {
   projectId: number;
@@ -19,14 +15,7 @@ const CommentLayout = ({
   createrId,
   loginUserId,
 }: CommentLayoutProps) => {
-  const { myData } = useMyProfileInfo();
   const { getCommentList, isLoading, isFetching } = useGetComment(projectId);
-
-  const profileImg = myData?.profileImg
-    ? `${import.meta.env.VITE_APP_IMAGE_CDN_URL}/${formatImgPath(
-        myData.profileImg
-      )}?w=86&h=86&fit=crop&crop=entropy&auto=format,enhance&q=60`
-    : DefaultImg;
 
   if (!getCommentList) {
     return (
@@ -48,7 +37,6 @@ const CommentLayout = ({
       </S.CommentCountsContainer>
 
       <S.CommentInput>
-        <Avatar size='55px' image={profileImg} />
         <CommentInput projectId={projectId} commentId={0} />
       </S.CommentInput>
 

--- a/src/components/user/comment/commentComponent/commentComponent/CommentComponent.styled.ts
+++ b/src/components/user/comment/commentComponent/commentComponent/CommentComponent.styled.ts
@@ -55,8 +55,11 @@ export const ReplyContent = styled.p`
 `;
 
 export const ReplyInput = styled.div`
-  width: 100%;
-  margin-left: 15px;
+  display: flex;
+  flex: 1;
+  width: 94%;
+  margin-left: 50px;
+  margin-top: 10px;
   margin-bottom: 10px;
 `;
 

--- a/src/components/user/comment/commentComponent/commentComponent/CommentComponent.tsx
+++ b/src/components/user/comment/commentComponent/commentComponent/CommentComponent.tsx
@@ -89,18 +89,17 @@ const CommentComponent = ({
               <S.ReplyContent>댓글 달기</S.ReplyContent>
             </S.ReplyInputButton>
           )}
-
-          {activateId === item.id && !onReplyMessage && (
-            <S.ReplyInput>
-              <CommentInput
-                reply={true}
-                projectId={projectId}
-                commentId={item.id}
-              />
-            </S.ReplyInput>
-          )}
         </S.CommentWrapper>
       </S.Wrapper>
+      {activateId === item.id && !onReplyMessage && (
+        <S.ReplyInput>
+          <CommentInput
+            reply={true}
+            projectId={projectId}
+            commentId={item.id}
+          />
+        </S.ReplyInput>
+      )}
     </S.Container>
   );
 };

--- a/src/components/user/comment/commentInput/CommentInput.tsx
+++ b/src/components/user/comment/commentInput/CommentInput.tsx
@@ -6,6 +6,10 @@ import usePostReply from '../../../../hooks/user/CommentHooks/usePostReply';
 import usePatchReply from '../../../../hooks/user/CommentHooks/usePatchReply';
 import usePostComment from '../../../../hooks/user/CommentHooks/usePostComment';
 import usePutComment from '../../../../hooks/user/CommentHooks/usePutComment';
+import { useMyProfileInfo } from '../../../../hooks/user/useMyInfo';
+import { formatImgPath } from '../../../../util/formatImgPath';
+import Avatar from '../../../common/avatar/Avatar';
+import DefaultImg from '../../../../assets/defaultImg.png';
 
 type FormValue = {
   commentInput: string;
@@ -38,7 +42,7 @@ const CommentInput = ({
     register,
     setValue,
   } = useForm<FormValue>();
-
+  const { myData } = useMyProfileInfo();
   const { isFocused, handleFocus, handleClick } = useInputFocus();
   const { createComment } = usePostComment(projectId);
   const { changeComment } = usePutComment(projectId, commentId);
@@ -46,6 +50,12 @@ const CommentInput = ({
   const { changeReply } = usePatchReply(recommentId, commentId, projectId);
 
   const hasInput = Boolean(watch('commentInput', ''));
+
+  const profileImg = myData?.profileImg
+    ? `${import.meta.env.VITE_APP_IMAGE_CDN_URL}/${formatImgPath(
+        myData.profileImg
+      )}?w=86&h=86&fit=crop&crop=entropy&auto=format,enhance&q=60`
+    : DefaultImg;
 
   const handleSubmit = (data: { commentInput: string }) => {
     if (reply) {
@@ -75,6 +85,7 @@ const CommentInput = ({
 
   return (
     <S.InputContainer>
+      <Avatar size={'55px'} image={profileImg} />
       <S.InputWrapper>
         <form
           onSubmit={


### PR DESCRIPTION
### 구현내용

- 댓글 컴포넌트에서 대댓글 input 스타일이 flex : 1이 구조로 인해 block 처리 되어 input 태그의 가로가 잘리는 버그 해결
- 프로필 사진이 원래 input 컴포넌트 옆에 붙어 있었던, 원래 상태로 복귀

### 연관이슈

close #314 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 댓글 입력 영역에 사용자의 프로필 이미지(아바타)가 표시됩니다.

- **스타일**
  - 답글 입력창의 레이아웃과 여백이 개선되어 더욱 깔끔하게 정렬됩니다.

- **리팩터**
  - 댓글 레이아웃에서 프로필 이미지 관련 요소가 제거되어 구조가 간소화되었습니다.
  - 답글 입력창의 위치가 변경되어 댓글 UI의 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->