### PR TITLE
관리자 메인 페이지 구현 ( issue #318 )

### DIFF
--- a/src/api/activityLog.api.ts
+++ b/src/api/activityLog.api.ts
@@ -1,4 +1,8 @@
-import type { ApiMyComments, ApiMyInquiries } from './../models/activityLog';
+import type {
+  ApiAllInquiries,
+  ApiMyComments,
+  ApiMyInquiries,
+} from './../models/activityLog';
 import { httpClient } from './http.api';
 
 export const getMyComments = async () => {
@@ -19,6 +23,16 @@ export const getMyInquiries = async () => {
     return response.data.data;
   } catch (e) {
     console.error('내 문의글 에러 ', e);
+    throw e;
+  }
+};
+
+export const getAllInquiries = async () => {
+  try {
+    const response = await httpClient.get<ApiAllInquiries>(`/inquiry`);
+    return response.data.data;
+  } catch (e) {
+    console.error('전체 문의 조회 에러', e);
     throw e;
   }
 };

--- a/src/api/activityLog.api.ts
+++ b/src/api/activityLog.api.ts
@@ -1,8 +1,5 @@
-import type {
-  ApiAllInquiries,
-  ApiMyComments,
-  ApiMyInquiries,
-} from './../models/activityLog';
+import { ApiAllInquiries } from '../models/admin/mainPreview';
+import type { ApiMyComments, ApiMyInquiries } from './../models/activityLog';
 import { httpClient } from './http.api';
 
 export const getMyComments = async () => {

--- a/src/api/alarm.api.ts
+++ b/src/api/alarm.api.ts
@@ -1,4 +1,5 @@
 import type { ApiAlarmList } from '../models/alarm';
+import useAuthStore from '../store/authStore';
 import { httpClient } from './http.api';
 
 export const getAlarmList = async () => {
@@ -36,14 +37,19 @@ export const patchAlarm = async (id: number) => {
 };
 
 export const testLiveAlarm = async () => {
-  try {
-    const response = await httpClient.get<ApiAlarmList>(
-      `/user/send-alarm?alarmFilter=0`
-    );
+  const { accessToken } = useAuthStore.getState();
+  if (accessToken) {
+    try {
+      const response = await httpClient.get<ApiAlarmList>(
+        `/user/send-alarm?alarmFilter=0`
+      );
 
-    return response;
-  } catch (e) {
-    console.error(e);
-    throw e;
+      return response;
+    } catch (e) {
+      console.error(e);
+      throw e;
+    }
+  } else {
+    return;
   }
 };

--- a/src/api/alarm.api.ts
+++ b/src/api/alarm.api.ts
@@ -50,6 +50,6 @@ export const testLiveAlarm = async () => {
       throw e;
     }
   } else {
-    return;
+    throw new Error('인증 토큰이 없습니다.');
   }
 };

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,4 +1,9 @@
-import type { ApiOauth, ApiVerifyNickname, VerifyEmail } from '../models/auth';
+import {
+  ApiGetAllUsers,
+  type ApiOauth,
+  type ApiVerifyNickname,
+  type VerifyEmail,
+} from '../models/auth';
 import { httpClient } from './http.api';
 import { loginFormValues } from '../pages/login/Login';
 import { registerFormValues } from '../pages/user/register/Register';
@@ -95,6 +100,16 @@ export const getOauthLogin = async (oauthAccessToken: string) => {
     });
 
     return response.data;
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};
+
+export const getAllUsers = async () => {
+  try {
+    const response = await httpClient.get<ApiGetAllUsers>(`/users`);
+    return response.data.data;
   } catch (e) {
     console.error(e);
     throw e;

--- a/src/api/report.api.ts
+++ b/src/api/report.api.ts
@@ -1,4 +1,4 @@
-import { ApiAllReports, type ApiPostContent } from '../models/report';
+import { type ApiAllReports, type ApiPostContent } from '../models/report';
 import { httpClient } from './http.api';
 
 export const postReport = async (formData: ApiPostContent) => {

--- a/src/api/report.api.ts
+++ b/src/api/report.api.ts
@@ -1,4 +1,4 @@
-import type { ApiPostContent } from '../models/report';
+import { ApiAllReports, type ApiPostContent } from '../models/report';
 import { httpClient } from './http.api';
 
 export const postReport = async (formData: ApiPostContent) => {
@@ -11,5 +11,15 @@ export const postReport = async (formData: ApiPostContent) => {
   } catch (error) {
     console.error(error);
     throw error;
+  }
+};
+
+export const getAllReports = async () => {
+  try {
+    const response = await httpClient.get<ApiAllReports>(`/reports`);
+    return response.data.data;
+  } catch (e) {
+    console.error(e);
+    throw e;
   }
 };

--- a/src/components/admin/mainCard/graphCard/GraphCard.styled.ts
+++ b/src/components/admin/mainCard/graphCard/GraphCard.styled.ts
@@ -1,3 +1,5 @@
 import styled from 'styled-components';
 
-export const Container = styled.div``;
+export const Container = styled.div`
+  height: 350px;
+`;

--- a/src/components/admin/mainCard/graphCard/GraphCard.tsx
+++ b/src/components/admin/mainCard/graphCard/GraphCard.tsx
@@ -1,8 +1,97 @@
 import React from 'react';
 import * as S from './GraphCard.styled';
+import { Line } from 'react-chartjs-2';
+import 'chart.js/auto';
+import { ChartData, ChartOptions } from 'chart.js';
 
 const GraphCard = () => {
-  return <S.Container>GraphCard Component</S.Container>;
+  return (
+    <S.Container>
+      <Line data={data} options={options} />
+    </S.Container>
+  );
+};
+
+const data: ChartData<'line'> = {
+  labels: [
+    '월요일',
+    '화요일',
+    '수요일',
+    '목요일',
+    '금요일',
+    '토요일',
+    '일요일',
+  ],
+  datasets: [
+    {
+      label: '방문자 수',
+      data: [8, 6, 4, 0, 7, 5, 3],
+      fill: true,
+      backgroundColor: 'rgba(54, 162, 235, 0.2)',
+      borderColor: 'rgba(54, 162, 235, 1)',
+      borderWidth: 2,
+      tension: 0.3,
+      pointRadius: 5,
+      pointBackgroundColor: '#ffffff',
+      pointBorderColor: 'rgba(54, 162, 235, 1)',
+      pointBorderWidth: 2,
+      pointHoverRadius: 6,
+    },
+  ],
+};
+
+const options: ChartOptions<'line'> = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      display: false,
+    },
+    tooltip: {
+      enabled: true,
+    },
+    title: {
+      display: false,
+    },
+  },
+  scales: {
+    x: {
+      grid: {
+        display: true,
+        borderDash: [5, 5],
+        color: 'rgba(0,0,0,0.1)',
+      },
+      ticks: {
+        font: {
+          size: 14,
+        },
+        color: '#333',
+      },
+    },
+    y: {
+      grid: {
+        display: true,
+        drawBorder: false,
+
+        borderDash: [5, 5],
+        color: 'rgba(0,0,0,0.1)',
+      },
+      ticks: {
+        stepSize: 2,
+        font: {
+          size: 14,
+        },
+        color: '#333',
+        callback: (value) => `${value}`,
+      },
+      beginAtZero: true,
+      suggestedMax: 8,
+    },
+  },
+  animation: {
+    duration: 800,
+    easing: 'easeOutQuart',
+  },
 };
 
 export default GraphCard;

--- a/src/components/admin/previewComponent/allUserPreview/AllUserPreview.styled.ts
+++ b/src/components/admin/previewComponent/allUserPreview/AllUserPreview.styled.ts
@@ -1,3 +1,44 @@
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-export const Container = styled.div``;
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 10px;
+`;
+
+export const UserArea = styled.div`
+  display: flex;
+`;
+
+export const ContentArea = styled(Link)`
+  margin-left: 16px;
+`;
+
+export const NickName = styled.p`
+  font-size: 14px;
+`;
+
+export const Email = styled.p`
+  font-size: 9px;
+  opacity: 50%;
+`;
+
+export const MoveToUsersArea = styled(Link)`
+  display: flex;
+  align-items: center;
+`;
+
+export const Text = styled.p`
+  font-size: 9px;
+`;
+
+export const Arrow = styled.img`
+  width: 10px;
+  height: 10px;
+`;

--- a/src/components/admin/previewComponent/allUserPreview/AllUserPreview.styled.ts
+++ b/src/components/admin/previewComponent/allUserPreview/AllUserPreview.styled.ts
@@ -26,7 +26,7 @@ export const NickName = styled.p`
 
 export const Email = styled.p`
   font-size: 9px;
-  opacity: 50%;
+  opacity: 0.5;
 `;
 
 export const MoveToUsersArea = styled(Link)`

--- a/src/components/admin/previewComponent/allUserPreview/AllUserPreview.styled.ts
+++ b/src/components/admin/previewComponent/allUserPreview/AllUserPreview.styled.ts
@@ -39,6 +39,6 @@ export const Text = styled.p`
 `;
 
 export const Arrow = styled.img`
-  width: 10px;
-  height: 10px;
+  width: 11px;
+  height: 11px;
 `;

--- a/src/components/admin/previewComponent/allUserPreview/AllUserPreview.tsx
+++ b/src/components/admin/previewComponent/allUserPreview/AllUserPreview.tsx
@@ -4,9 +4,18 @@ import { useGetAllUsers } from '../../../../hooks/admin/useGetAllUsers';
 import Avatar from '../../../common/avatar/Avatar';
 import { ADMIN_ROUTE } from '../../../../constants/routes';
 import arrow_right from '../../../../assets/ArrowRight.svg';
+import LoadingSpinner from '../../../common/loadingSpinner/LoadingSpinner';
 
 const AllUserPreview = () => {
-  const { allUserData, isLoading } = useGetAllUsers();
+  const { allUserData, isLoading, isFetching } = useGetAllUsers();
+
+  if (isLoading || isFetching) {
+    return <LoadingSpinner />;
+  }
+
+  if (!allUserData || allUserData.length === 0) {
+    return <S.Container>가입된 회원이 없습니다.</S.Container>;
+  }
 
   const previewList = allUserData
     ? allUserData.length > 6
@@ -19,7 +28,7 @@ const AllUserPreview = () => {
       {previewList?.map((user) => (
         <S.Wrapper key={user.id}>
           <S.UserArea>
-            <Avatar image={undefined} size='40px' />
+            <Avatar image={user.user.img} size='40px' />
             <S.ContentArea to={`${ADMIN_ROUTE.allUser}/${user.id}`}>
               <S.NickName>{user.user.nickname}</S.NickName>
               <S.Email>{user.email}</S.Email>

--- a/src/components/admin/previewComponent/allUserPreview/AllUserPreview.tsx
+++ b/src/components/admin/previewComponent/allUserPreview/AllUserPreview.tsx
@@ -1,8 +1,38 @@
 import React from 'react';
 import * as S from './AllUserPreview.styled';
+import { useGetAllUsers } from '../../../../hooks/admin/useGetAllUsers';
+import Avatar from '../../../common/avatar/Avatar';
+import { ADMIN_ROUTE } from '../../../../constants/routes';
+import arrow_right from '../../../../assets/ArrowRight.svg';
 
 const AllUserPreview = () => {
-  return <S.Container>AllUserPreview Component</S.Container>;
+  const { allUserData, isLoading } = useGetAllUsers();
+
+  const previewList = allUserData
+    ? allUserData.length > 6
+      ? allUserData.slice(0, 4)
+      : allUserData
+    : [];
+
+  return (
+    <S.Container>
+      {previewList?.map((user) => (
+        <S.Wrapper key={user.id}>
+          <S.UserArea>
+            <Avatar image={undefined} size='40px' />
+            <S.ContentArea to={`${ADMIN_ROUTE.allUser}/${user.id}`}>
+              <S.NickName>{user.user.nickname}</S.NickName>
+              <S.Email>{user.email}</S.Email>
+            </S.ContentArea>
+          </S.UserArea>
+          <S.MoveToUsersArea to={`${ADMIN_ROUTE.allUser}/${user.id}`}>
+            <S.Text>상세 보기</S.Text>
+            <S.Arrow src={arrow_right} />
+          </S.MoveToUsersArea>
+        </S.Wrapper>
+      ))}
+    </S.Container>
+  );
 };
 
 export default AllUserPreview;

--- a/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.styled.ts
+++ b/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.styled.ts
@@ -23,7 +23,7 @@ export const Inquiry = styled(Link)`
 
 export const Category = styled.p`
   font-size: 9px;
-  opacity: 50%;
+  opacity: 0.5;
 `;
 
 export const Title = styled.p`
@@ -37,14 +37,14 @@ export const StateArea = styled.div`
   display: flex;
 `;
 
-export const Date = styled.p`
+export const InquiriesDate = styled.p`
   font-size: 9px;
-  opacity: 50%;
+  opacity: 0.5;
 `;
 
 export const Divider = styled.p`
   font-size: 9px;
-  opacity: 20%;
+  opacity: 0.2;
   margin-left: 3px;
   margin-right: 3px;
 `;

--- a/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.styled.ts
+++ b/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.styled.ts
@@ -1,3 +1,51 @@
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-export const Container = styled.div``;
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 10px;
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin-top: 16px;
+`;
+
+export const Inquiry = styled(Link)`
+  margin-left: 16px;
+`;
+
+export const Category = styled.p`
+  font-size: 10px;
+  opacity: 50%;
+`;
+
+export const Title = styled.span`
+  font-size: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const StateArea = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const Date = styled.p`
+  font-size: 10px;
+  opacity: 50%;
+`;
+
+export const Divider = styled.p`
+  opacity: 20%;
+  margin-left: 3px;
+  margin-right: 3px;
+`;
+
+export const InquiryState = styled.p<{ $isCompleted: boolean }>`
+  font-size: 10px;
+  color: ${({ $isCompleted }) => ($isCompleted ? `#07DE00` : `#DE1A00`)};
+`;

--- a/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.styled.ts
+++ b/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.styled.ts
@@ -4,19 +4,17 @@ import styled from 'styled-components';
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
-  margin-left: 10px;
 `;
 
 export const Wrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding: 10px;
 `;
 
 export const Content = styled.div`
   display: flex;
-  align-items: center;
-  margin-top: 16px;
 `;
 
 export const Inquiry = styled(Link)`
@@ -28,7 +26,7 @@ export const Category = styled.p`
   opacity: 50%;
 `;
 
-export const Title = styled.span`
+export const Title = styled.p`
   font-size: 13px;
   white-space: nowrap;
   overflow: hidden;
@@ -37,7 +35,6 @@ export const Title = styled.span`
 
 export const StateArea = styled.div`
   display: flex;
-  align-items: center;
 `;
 
 export const Date = styled.p`
@@ -46,6 +43,7 @@ export const Date = styled.p`
 `;
 
 export const Divider = styled.p`
+  font-size: 9px;
   opacity: 20%;
   margin-left: 3px;
   margin-right: 3px;
@@ -58,13 +56,14 @@ export const InquiryState = styled.p<{ $isCompleted: boolean }>`
 
 export const MoveToInquiryArea = styled(Link)`
   display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 10px;
-  margin-right: 10px;
-  margin-top: 20px;
+  font-size: 9px;
 `;
 
-export const Text = styled.p``;
+export const Text = styled.p`
+  font-size: 9px;
+`;
 
-export const Arrow = styled.img``;
+export const Arrow = styled.img`
+  width: 11px;
+  height: 11px;
+`;

--- a/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.styled.ts
+++ b/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.styled.ts
@@ -9,6 +9,12 @@ export const Container = styled.div`
 
 export const Wrapper = styled.div`
   display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const Content = styled.div`
+  display: flex;
   align-items: center;
   margin-top: 16px;
 `;
@@ -18,12 +24,12 @@ export const Inquiry = styled(Link)`
 `;
 
 export const Category = styled.p`
-  font-size: 10px;
+  font-size: 9px;
   opacity: 50%;
 `;
 
 export const Title = styled.span`
-  font-size: 14px;
+  font-size: 13px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -35,7 +41,7 @@ export const StateArea = styled.div`
 `;
 
 export const Date = styled.p`
-  font-size: 10px;
+  font-size: 9px;
   opacity: 50%;
 `;
 
@@ -46,6 +52,19 @@ export const Divider = styled.p`
 `;
 
 export const InquiryState = styled.p<{ $isCompleted: boolean }>`
-  font-size: 10px;
+  font-size: 9px;
   color: ${({ $isCompleted }) => ($isCompleted ? `#07DE00` : `#DE1A00`)};
 `;
+
+export const MoveToInquiryArea = styled(Link)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 10px;
+  margin-right: 10px;
+  margin-top: 20px;
+`;
+
+export const Text = styled.p``;
+
+export const Arrow = styled.img``;

--- a/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.tsx
+++ b/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.tsx
@@ -1,9 +1,7 @@
-import React from 'react';
 import * as S from './InquiresPreview.styled';
 import { useGetAllInquiries } from '../../../../hooks/admin/useGetAllInquiries';
 import Avatar from '../../../common/avatar/Avatar';
 import { ADMIN_ROUTE } from '../../../../constants/routes';
-import { Link } from 'react-router-dom';
 import arrow_right from '../../../../assets/ArrowRight.svg';
 
 const InquiresPreview = () => {
@@ -11,7 +9,7 @@ const InquiresPreview = () => {
 
   const previewList = allInquiriesData
     ? allInquiriesData.length > 6
-      ? allInquiriesData.slice(-4)
+      ? allInquiriesData.slice(0, 4)
       : allInquiriesData
     : [];
 
@@ -21,7 +19,7 @@ const InquiresPreview = () => {
         <S.Wrapper key={inquiry.id}>
           <S.Content>
             {/* <Link to={`${ADMIN_ROUTE.}`} */}
-            <Avatar image={inquiry.user.img} size='38px' />
+            <Avatar image={inquiry.user.img} size='40px' />
             <S.Inquiry to={`${ADMIN_ROUTE.inquiries}/${inquiry.id}`}>
               <S.Category>{inquiry.category}</S.Category>
               <S.Title>{inquiry.title}</S.Title>

--- a/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.tsx
+++ b/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.tsx
@@ -13,7 +13,7 @@ const InquiresPreview = () => {
   }
 
   if (!allInquiriesData || allInquiriesData.length === 0) {
-    return <S.Container>등록된 공지사항이 없습니다.</S.Container>;
+    return <S.Container>등록된 문의가 없습니다.</S.Container>;
   }
 
   const previewList = allInquiriesData

--- a/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.tsx
+++ b/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.tsx
@@ -3,9 +3,18 @@ import { useGetAllInquiries } from '../../../../hooks/admin/useGetAllInquiries';
 import Avatar from '../../../common/avatar/Avatar';
 import { ADMIN_ROUTE } from '../../../../constants/routes';
 import arrow_right from '../../../../assets/ArrowRight.svg';
+import LoadingSpinner from '../../../common/loadingSpinner/LoadingSpinner';
 
 const InquiresPreview = () => {
-  const { allInquiriesData } = useGetAllInquiries();
+  const { allInquiriesData, isLoading, isFetching } = useGetAllInquiries();
+
+  if (isLoading || isFetching) {
+    return <LoadingSpinner />;
+  }
+
+  if (!allInquiriesData || allInquiriesData.length === 0) {
+    return <S.Container>등록된 공지사항이 없습니다.</S.Container>;
+  }
 
   const previewList = allInquiriesData
     ? allInquiriesData.length > 6
@@ -24,7 +33,7 @@ const InquiresPreview = () => {
               <S.Category>{inquiry.category}</S.Category>
               <S.Title>{inquiry.title}</S.Title>
               <S.StateArea>
-                <S.Date>{inquiry.createdAt}</S.Date>
+                <S.InquiriesDate>{inquiry.createdAt}</S.InquiriesDate>
                 <S.Divider>|</S.Divider>
                 <S.InquiryState $isCompleted={inquiry.state}>
                   {inquiry.state ? '답변 완료' : '답변 대기 중'}

--- a/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.tsx
+++ b/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.tsx
@@ -4,6 +4,7 @@ import { useGetAllInquiries } from '../../../../hooks/admin/useGetAllInquiries';
 import Avatar from '../../../common/avatar/Avatar';
 import { ADMIN_ROUTE } from '../../../../constants/routes';
 import { Link } from 'react-router-dom';
+import arrow_right from '../../../../assets/ArrowRight.svg';
 
 const InquiresPreview = () => {
   const { allInquiriesData } = useGetAllInquiries();
@@ -18,19 +19,25 @@ const InquiresPreview = () => {
     <S.Container>
       {previewList?.map((inquiry) => (
         <S.Wrapper key={inquiry.id}>
-          {/* <Link to={`${ADMIN_ROUTE.}`} */}
-          <Avatar image={inquiry.user.img} size='41px' />
-          <S.Inquiry to={`${ADMIN_ROUTE.inquiries}/${inquiry.id}`}>
-            <S.Category>{inquiry.category}</S.Category>
-            <S.Title>{inquiry.title}</S.Title>
-            <S.StateArea>
-              <S.Date>{inquiry.createdAt}</S.Date>
-              <S.Divider>|</S.Divider>
-              <S.InquiryState $isCompleted={inquiry.state}>
-                {inquiry.state ? '답변 완료' : '답변 대기 중'}
-              </S.InquiryState>
-            </S.StateArea>
-          </S.Inquiry>
+          <S.Content>
+            {/* <Link to={`${ADMIN_ROUTE.}`} */}
+            <Avatar image={inquiry.user.img} size='38px' />
+            <S.Inquiry to={`${ADMIN_ROUTE.inquiries}/${inquiry.id}`}>
+              <S.Category>{inquiry.category}</S.Category>
+              <S.Title>{inquiry.title}</S.Title>
+              <S.StateArea>
+                <S.Date>{inquiry.createdAt}</S.Date>
+                <S.Divider>|</S.Divider>
+                <S.InquiryState $isCompleted={inquiry.state}>
+                  {inquiry.state ? '답변 완료' : '답변 대기 중'}
+                </S.InquiryState>
+              </S.StateArea>
+            </S.Inquiry>
+          </S.Content>
+          <S.MoveToInquiryArea to={`${ADMIN_ROUTE.inquiries}/${inquiry.id}`}>
+            <S.Text>상세 보기</S.Text>
+            <S.Arrow src={arrow_right} />
+          </S.MoveToInquiryArea>
         </S.Wrapper>
       ))}
     </S.Container>

--- a/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.tsx
+++ b/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.tsx
@@ -1,8 +1,40 @@
 import React from 'react';
 import * as S from './InquiresPreview.styled';
+import { useGetAllInquiries } from '../../../../hooks/admin/useGetAllInquiries';
+import Avatar from '../../../common/avatar/Avatar';
+import { ADMIN_ROUTE } from '../../../../constants/routes';
+import { Link } from 'react-router-dom';
 
 const InquiresPreview = () => {
-  return <S.Container>InquiresPreview Component</S.Container>;
+  const { allInquiriesData } = useGetAllInquiries();
+
+  const previewList = allInquiriesData
+    ? allInquiriesData.length > 6
+      ? allInquiriesData.slice(-4)
+      : allInquiriesData
+    : [];
+
+  return (
+    <S.Container>
+      {previewList?.map((inquiry) => (
+        <S.Wrapper key={inquiry.id}>
+          {/* <Link to={`${ADMIN_ROUTE.}`} */}
+          <Avatar image={inquiry.user.img} size='41px' />
+          <S.Inquiry to={`${ADMIN_ROUTE.inquiries}/${inquiry.id}`}>
+            <S.Category>{inquiry.category}</S.Category>
+            <S.Title>{inquiry.title}</S.Title>
+            <S.StateArea>
+              <S.Date>{inquiry.createdAt}</S.Date>
+              <S.Divider>|</S.Divider>
+              <S.InquiryState $isCompleted={inquiry.state}>
+                {inquiry.state ? '답변 완료' : '답변 대기 중'}
+              </S.InquiryState>
+            </S.StateArea>
+          </S.Inquiry>
+        </S.Wrapper>
+      ))}
+    </S.Container>
+  );
 };
 
 export default InquiresPreview;

--- a/src/components/admin/previewComponent/noticePreview/NoticePreview.tsx
+++ b/src/components/admin/previewComponent/noticePreview/NoticePreview.tsx
@@ -2,13 +2,25 @@ import React from 'react';
 import * as S from './NoticePreview.styled';
 import { useGetNotice } from '../../../../hooks/user/useGetNotice';
 import line from '../../../../assets/line.svg';
+import LoadingSpinner from '../../../common/loadingSpinner/LoadingSpinner';
 
 const NoticePreview = () => {
-  const { noticeData } = useGetNotice({ keyword: '', page: 1 });
+  const { noticeData, isLoading, isFetching } = useGetNotice({
+    keyword: '',
+    page: 1,
+  });
+
+  if (isLoading || isFetching) {
+    return <LoadingSpinner />;
+  }
+
+  if (!noticeData?.notices || noticeData.notices.length === 0) {
+    return <S.Container>공지사힝이 없습니다.</S.Container>;
+  }
 
   return (
     <S.Container>
-      {noticeData?.notices.map((notice) => (
+      {noticeData.notices.map((notice) => (
         <S.Wrapper key={notice.id}>
           <S.Dot src={line} />
           <S.NoticeTitle>{notice.title}</S.NoticeTitle>

--- a/src/components/admin/previewComponent/reportsPreview/ReportsPreview.styled.ts
+++ b/src/components/admin/previewComponent/reportsPreview/ReportsPreview.styled.ts
@@ -1,3 +1,68 @@
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-export const Container = styled.div``;
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px;
+`;
+
+export const ReportArea = styled(Link)`
+  display: flex;
+`;
+
+export const ContentArea = styled.div`
+  margin-left: 16px;
+`;
+
+export const ImposedCount = styled.div`
+  font-size: 9px;
+  opacity: 50%;
+`;
+
+export const Category = styled.p`
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const StateArea = styled.div`
+  display: flex;
+`;
+
+export const Date = styled.p`
+  font-size: 9px;
+  opacity: 50%;
+`;
+
+export const Divider = styled.p`
+  font-size: 9px;
+  opacity: 20%;
+  margin-left: 3px;
+  margin-right: 3px;
+`;
+
+export const IsImposed = styled.p<{ $isImposed: boolean }>`
+  font-size: 9px;
+  color: ${({ $isImposed }) => ($isImposed ? `#07DE00` : `#DE1A00`)};
+`;
+
+export const MoveToReportsArea = styled(Link)`
+  display: flex;
+`;
+
+export const Text = styled.p`
+  font-size: 9px;
+`;
+
+export const Arrow = styled.img`
+  width: 11px;
+  height: 11px;
+`;

--- a/src/components/admin/previewComponent/reportsPreview/ReportsPreview.styled.ts
+++ b/src/components/admin/previewComponent/reportsPreview/ReportsPreview.styled.ts
@@ -23,7 +23,7 @@ export const ContentArea = styled.div`
 
 export const ImposedCount = styled.div`
   font-size: 9px;
-  opacity: 50%;
+  opacity: 0.5;
 `;
 
 export const Category = styled.p`
@@ -37,14 +37,14 @@ export const StateArea = styled.div`
   display: flex;
 `;
 
-export const Date = styled.p`
+export const ReportDate = styled.p`
   font-size: 9px;
-  opacity: 50%;
+  opacity: 0.5;
 `;
 
 export const Divider = styled.p`
   font-size: 9px;
-  opacity: 20%;
+  opacity: 0.2;
   margin-left: 3px;
   margin-right: 3px;
 `;

--- a/src/components/admin/previewComponent/reportsPreview/ReportsPreview.tsx
+++ b/src/components/admin/previewComponent/reportsPreview/ReportsPreview.tsx
@@ -1,8 +1,44 @@
-import React from 'react';
 import * as S from './ReportsPreview.styled';
+import { useGetAllReports } from '../../../../hooks/admin/useGetAllReports';
+import Avatar from '../../../common/avatar/Avatar';
+import arrow_right from '../../../../assets/ArrowRight.svg';
+import { ADMIN_ROUTE } from '../../../../constants/routes';
 
 const ReportsPreview = () => {
-  return <S.Container>ReportsPreview Component</S.Container>;
+  const { allReportsData } = useGetAllReports();
+
+  const previewList = allReportsData
+    ? allReportsData.length > 6
+      ? allReportsData.slice(0, 4)
+      : allReportsData
+    : [];
+
+  return (
+    <S.Container>
+      {previewList?.map((report) => (
+        <S.Wrapper>
+          <S.ReportArea to={`${ADMIN_ROUTE.reports}/${report.id}`}>
+            <Avatar image={report.user.img} size='40px' />
+            <S.ContentArea>
+              <S.ImposedCount>{report.imposedCount} 번</S.ImposedCount>
+              <S.Category>{report.category}</S.Category>
+              <S.StateArea>
+                <S.Date>{report.createdAt}</S.Date>
+                <S.Divider>|</S.Divider>
+                <S.IsImposed $isImposed={report.IsImposed}>
+                  {report.IsImposed ? '검토 완료' : '검토 미완료'}
+                </S.IsImposed>
+              </S.StateArea>
+            </S.ContentArea>
+          </S.ReportArea>
+          <S.MoveToReportsArea to={`${ADMIN_ROUTE.reports}/${report.id}`}>
+            <S.Text>신고 상세 보기</S.Text>
+            <S.Arrow src={arrow_right}></S.Arrow>
+          </S.MoveToReportsArea>
+        </S.Wrapper>
+      ))}
+    </S.Container>
+  );
 };
 
 export default ReportsPreview;

--- a/src/components/admin/previewComponent/reportsPreview/ReportsPreview.tsx
+++ b/src/components/admin/previewComponent/reportsPreview/ReportsPreview.tsx
@@ -16,17 +16,17 @@ const ReportsPreview = () => {
   return (
     <S.Container>
       {previewList?.map((report) => (
-        <S.Wrapper>
+        <S.Wrapper key={report.id}>
           <S.ReportArea to={`${ADMIN_ROUTE.reports}/${report.id}`}>
             <Avatar image={report.user.img} size='40px' />
             <S.ContentArea>
               <S.ImposedCount>{report.imposedCount} 번</S.ImposedCount>
               <S.Category>{report.category}</S.Category>
               <S.StateArea>
-                <S.Date>{report.createdAt}</S.Date>
+                <S.ReportDate>{report.createdAt}</S.ReportDate>
                 <S.Divider>|</S.Divider>
-                <S.IsImposed $isImposed={report.IsImposed}>
-                  {report.IsImposed ? '검토 완료' : '검토 미완료'}
+                <S.IsImposed $isImposed={report.isImposed}>
+                  {report.isImposed ? '검토 완료' : '검토 미완료'}
                 </S.IsImposed>
               </S.StateArea>
             </S.ContentArea>

--- a/src/constants/admin/mainItems.ts
+++ b/src/constants/admin/mainItems.ts
@@ -20,7 +20,7 @@ export const cardList: CardItem[] = [
     Component: AllUserPreview,
   },
   {
-    key: 'inquires',
+    key: 'inquiries',
     title: '문의 확인',
     link: `${ADMIN_ROUTE.inquiries}`,
     Component: InquiresPreview,

--- a/src/constants/admin/mainItems.ts
+++ b/src/constants/admin/mainItems.ts
@@ -14,10 +14,10 @@ export interface CardItem {
 
 export const cardList: CardItem[] = [
   {
-    key: 'notice',
-    title: '공지사항',
-    link: `${ADMIN_ROUTE.notice}`,
-    Component: NoticePreview,
+    key: 'allUsers',
+    title: '전체 회원 조회',
+    link: `${ADMIN_ROUTE.allUser}`,
+    Component: AllUserPreview,
   },
   {
     key: 'inquires',
@@ -32,14 +32,14 @@ export const cardList: CardItem[] = [
     Component: ReportsPreview,
   },
   {
-    key: 'allUsers',
-    title: '전체 회원 조회',
-    link: `${ADMIN_ROUTE.allUser}`,
-    Component: AllUserPreview,
-  },
-  {
     key: 'Graph',
     title: '방문자 현황',
     Component: GraphCard,
+  },
+  {
+    key: 'notice',
+    title: '공지사항',
+    link: `${ADMIN_ROUTE.notice}`,
+    Component: NoticePreview,
   },
 ];

--- a/src/hooks/admin/useGetAllInquiries.ts
+++ b/src/hooks/admin/useGetAllInquiries.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { getAllInquiries } from '../../api/activityLog.api';
-import { ActivityLog } from '../queries/user/keys';
+import { Inquiries } from '../queries/user/keys';
 
 export const useGetAllInquiries = () => {
   const {
@@ -8,7 +8,7 @@ export const useGetAllInquiries = () => {
     isLoading,
     isFetching,
   } = useQuery({
-    queryKey: [ActivityLog.allInquiries],
+    queryKey: [Inquiries.allInquiries],
     queryFn: () => getAllInquiries(),
   });
 

--- a/src/hooks/admin/useGetAllInquiries.ts
+++ b/src/hooks/admin/useGetAllInquiries.ts
@@ -3,10 +3,14 @@ import { getAllInquiries } from '../../api/activityLog.api';
 import { ActivityLog } from '../queries/user/keys';
 
 export const useGetAllInquiries = () => {
-  const { data: allInquiriesData, isLoading } = useQuery({
+  const {
+    data: allInquiriesData,
+    isLoading,
+    isFetching,
+  } = useQuery({
     queryKey: [ActivityLog.allInquiries],
     queryFn: () => getAllInquiries(),
   });
 
-  return { allInquiriesData, isLoading };
+  return { allInquiriesData, isLoading, isFetching };
 };

--- a/src/hooks/admin/useGetAllInquiries.ts
+++ b/src/hooks/admin/useGetAllInquiries.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAllInquiries } from '../../api/activityLog.api';
+import { ActivityLog } from '../queries/user/keys';
+
+export const useGetAllInquiries = () => {
+  const { data: allInquiriesData, isLoading } = useQuery({
+    queryKey: [ActivityLog.allInquiries],
+    queryFn: () => getAllInquiries(),
+  });
+
+  return { allInquiriesData, isLoading };
+};

--- a/src/hooks/admin/useGetAllReports.ts
+++ b/src/hooks/admin/useGetAllReports.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { ReportData } from '../queries/user/keys';
+import { getAllReports } from '../../api/report.api';
+
+export const useGetAllReports = () => {
+  const { data: allReportsData, isLoading } = useQuery({
+    queryKey: [ReportData.allReports],
+    queryFn: () => getAllReports(),
+  });
+
+  return { allReportsData, isLoading };
+};

--- a/src/hooks/admin/useGetAllUsers.ts
+++ b/src/hooks/admin/useGetAllUsers.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { ReportData } from '../queries/user/keys';
+import { getAllUsers } from '../../api/auth.api';
+
+export const useGetAllUsers = () => {
+  const { data: allUserData, isLoading } = useQuery({
+    queryKey: [ReportData.allReports],
+    queryFn: () => getAllUsers(),
+  });
+
+  return { allUserData, isLoading };
+};

--- a/src/hooks/admin/useGetAllUsers.ts
+++ b/src/hooks/admin/useGetAllUsers.ts
@@ -1,12 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
-import { ReportData } from '../queries/user/keys';
+import { UserData } from '../queries/user/keys';
 import { getAllUsers } from '../../api/auth.api';
 
 export const useGetAllUsers = () => {
-  const { data: allUserData, isLoading } = useQuery({
-    queryKey: [ReportData.allReports],
+  const {
+    data: allUserData,
+    isLoading,
+    isFetching,
+  } = useQuery({
+    queryKey: [UserData.allUser],
     queryFn: () => getAllUsers(),
   });
 
-  return { allUserData, isLoading };
+  return { allUserData, isLoading, isFetching };
 };

--- a/src/hooks/queries/user/keys.ts
+++ b/src/hooks/queries/user/keys.ts
@@ -59,3 +59,7 @@ export const CustomerService = {
 export const ReportData = {
   allReports: ['AllReports'],
 };
+
+export const UserData = {
+  allUser: ['AllUser'],
+};

--- a/src/hooks/queries/user/keys.ts
+++ b/src/hooks/queries/user/keys.ts
@@ -47,6 +47,9 @@ export const ProjectMemberListEval = {
 export const ActivityLog = {
   myComments: ['MyComments'],
   myInquiries: ['MyInquiries'],
+};
+
+export const Inquiries = {
   allInquiries: ['AllInquiries'],
 };
 

--- a/src/hooks/queries/user/keys.ts
+++ b/src/hooks/queries/user/keys.ts
@@ -47,6 +47,7 @@ export const ProjectMemberListEval = {
 export const ActivityLog = {
   myComments: ['MyComments'],
   myInquiries: ['MyInquiries'],
+  allInquiries: ['AllInquiries'],
 };
 
 export const CustomerService = {

--- a/src/hooks/queries/user/keys.ts
+++ b/src/hooks/queries/user/keys.ts
@@ -55,3 +55,7 @@ export const CustomerService = {
   notice: 'notice',
   noticeDetail: 'noticeDetail',
 };
+
+export const ReportData = {
+  allReports: ['AllReports'],
+};

--- a/src/hooks/user/useGetNotice.ts
+++ b/src/hooks/user/useGetNotice.ts
@@ -6,12 +6,16 @@ import { CustomerService } from '../queries/user/keys';
 export const useGetNotice = (searchProperty: NoticeSearch) => {
   const { keyword, page } = searchProperty;
 
-  const { data: noticeData, isLoading } = useQuery({
+  const {
+    data: noticeData,
+    isLoading,
+    isFetching,
+  } = useQuery({
     queryKey: [CustomerService.notice, keyword, page],
     queryFn: () => getNotice(searchProperty),
     staleTime: Infinity,
     gcTime: Infinity,
   });
 
-  return { noticeData, isLoading };
+  return { noticeData, isLoading, isFetching };
 };

--- a/src/mock/applicant.ts
+++ b/src/mock/applicant.ts
@@ -4,7 +4,7 @@ import mockApplicantData from './mockApplicantData.json';
 import mockPassNonPassListData from './mockPassNonPassListData.json';
 
 export const applicantList = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/project/:projectId/applicants`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}project/:projectId/applicants`,
   () => {
     return HttpResponse.json(mockApplicantsData, {
       status: 200,
@@ -13,7 +13,9 @@ export const applicantList = http.get(
 );
 
 export const applicantInfo = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/project/:projectId/applicants/:userId`,
+  `${
+    import.meta.env.VITE_APP_API_BASE_URL
+  }project/:projectId/applicants/:userId`,
   () => {
     return HttpResponse.json(mockApplicantData, {
       status: 200,
@@ -22,7 +24,9 @@ export const applicantInfo = http.get(
 );
 
 export const passNonPassList = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/project/:projectId/applicants/results`,
+  `${
+    import.meta.env.VITE_APP_API_BASE_URL
+  }project/:projectId/applicants/results`,
   () => {
     return HttpResponse.json(mockPassNonPassListData, {
       status: 200,
@@ -31,7 +35,7 @@ export const passNonPassList = http.get(
 );
 
 export const passNonPass = http.put(
-  `${import.meta.env.VITE_API_BASE_URL}/project/:projectId/applicant`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}project/:projectId/applicant`,
   () => {
     return HttpResponse.json(
       { message: '합/불합 상태가 수정되었습니다.' },
@@ -43,7 +47,7 @@ export const passNonPass = http.put(
 );
 
 export const createApplicant = http.post(
-  `${import.meta.env.VITE_API_BASE_URL}/project/:projectId/applicant`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}project/:projectId/applicant`,
   () => {
     return HttpResponse.json({
       status: 200,

--- a/src/mock/auth.ts
+++ b/src/mock/auth.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
 export const login = http.post(
-  `${import.meta.env.VITE_API_BASE_URL}/auth/login`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}auth/login`,
   () => {
     return HttpResponse.json({
       status: 200,

--- a/src/mock/browser.ts
+++ b/src/mock/browser.ts
@@ -7,7 +7,7 @@ import {
   passNonPass,
   passNonPassList,
 } from './applicant';
-import { projectDetail } from './projectDetail';
+import { projectDetail, reportsAll } from './projectDetail';
 import {
   myPageAppliedProjectList,
   mypageEditProfile,
@@ -16,7 +16,11 @@ import {
   myPageProfile,
   myPageSkillTag,
 } from './mypage';
-import { userPageAppliedProjectList, userPageProfile } from './userpage';
+import {
+  userAll,
+  userPageAppliedProjectList,
+  userPageProfile,
+} from './userpage';
 import { login } from './auth';
 import { fetchProjectLists, fetchProjectStatistic } from './projectLists';
 import {
@@ -51,6 +55,8 @@ export const handlers = [
   login,
   createApplicant,
   createProject,
+  userAll,
+  reportsAll,
 ];
 
 export const worker = setupWorker(...handlers);

--- a/src/mock/browser.ts
+++ b/src/mock/browser.ts
@@ -55,8 +55,8 @@ export const handlers = [
   login,
   createApplicant,
   createProject,
-  userAll,
   reportsAll,
+  userAll,
 ];
 
 export const worker = setupWorker(...handlers);

--- a/src/mock/createProject.ts
+++ b/src/mock/createProject.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
 export const createProject = http.post(
-  `${import.meta.env.VITE_API_BASE_URL}/project`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}project`,
   () => {
     return HttpResponse.json({
       status: 200,

--- a/src/mock/manageProjectList.ts
+++ b/src/mock/manageProjectList.ts
@@ -2,7 +2,7 @@ import { HttpResponse, http } from 'msw';
 import mockManageMyprojectList from './mockProjectList.json';
 
 export const myProjectList = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/project/my`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}project/my`,
   () => {
     return HttpResponse.json(mockManageMyprojectList, {
       status: 200,
@@ -11,7 +11,7 @@ export const myProjectList = http.get(
 );
 
 export const sendResult = http.put(
-  `${import.meta.env.VITE_API_BASE_URL}/project/:projectId/close`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}project/:projectId/close`,
   () => {
     return HttpResponse.json(
       { message: '지원자들에게 결과를 전송했어요' },

--- a/src/mock/mockReports.json
+++ b/src/mock/mockReports.json
@@ -14,7 +14,7 @@
         }
       ],
       "IsImposed": false,
-      "createdAt": "2025-05-01T10:15:00+09:00"
+      "createdAt": "2025-05-01"
     },
     {
       "id": 2,
@@ -33,7 +33,7 @@
         }
       ],
       "IsImposed": true,
-      "createdAt": "2025-05-03T14:30:00+09:00"
+      "createdAt": "2025-05-03"
     },
     {
       "id": 3,
@@ -47,7 +47,7 @@
         }
       ],
       "IsImposed": false,
-      "createdAt": "2025-05-05T09:45:00+09:00"
+      "createdAt": "2025-05-05"
     },
     {
       "id": 4,
@@ -61,7 +61,7 @@
         }
       ],
       "IsImposed": true,
-      "createdAt": "2025-05-07T16:20:00+09:00"
+      "createdAt": "2025-05-07"
     },
     {
       "id": 5,
@@ -80,7 +80,7 @@
         }
       ],
       "IsImposed": false,
-      "createdAt": "2025-05-09T11:10:00+09:00"
+      "createdAt": "2025-05-09"
     },
     {
       "id": 6,
@@ -94,7 +94,7 @@
         }
       ],
       "IsImposed": true,
-      "createdAt": "2025-05-11T13:55:00+09:00"
+      "createdAt": "2025-05-11"
     },
     {
       "id": 7,
@@ -113,7 +113,7 @@
         }
       ],
       "IsImposed": false,
-      "createdAt": "2025-05-13T18:05:00+09:00"
+      "createdAt": "2025-05-13"
     },
     {
       "id": 8,
@@ -127,7 +127,7 @@
         }
       ],
       "IsImposed": true,
-      "createdAt": "2025-05-15T08:25:00+09:00"
+      "createdAt": "2025-05-15"
     },
     {
       "id": 9,
@@ -141,7 +141,7 @@
         }
       ],
       "IsImposed": true,
-      "createdAt": "2025-05-17T12:40:00+09:00"
+      "createdAt": "2025-05-17"
     },
     {
       "id": 10,
@@ -160,7 +160,7 @@
         }
       ],
       "IsImposed": false,
-      "createdAt": "2025-05-19T20:15:00+09:00"
+      "createdAt": "2025-05-19"
     }
   ]
 }

--- a/src/mock/mockReports.json
+++ b/src/mock/mockReports.json
@@ -6,13 +6,11 @@
       "id": 1,
       "imposedCount": 3,
       "category": "스팸 신고",
-      "user": [
-        {
-          "id": 301,
-          "nickname": "alice",
-          "img": "https://example.com/images/alice.png"
-        }
-      ],
+      "user": {
+        "id": 301,
+        "nickname": "alice",
+        "img": "https://example.com/images/alice.png"
+      },
       "IsImposed": false,
       "createdAt": "2025-05-01"
     },
@@ -20,18 +18,11 @@
       "id": 2,
       "imposedCount": 5,
       "category": "욕설/비방",
-      "user": [
-        {
-          "id": 302,
-          "nickname": "bob",
-          "img": "https://example.com/images/bob.jpg"
-        },
-        {
-          "id": 303,
-          "nickname": "charlie",
-          "img": "https://example.com/images/charlie.jpeg"
-        }
-      ],
+      "user": {
+        "id": 303,
+        "nickname": "charlie",
+        "img": "https://example.com/images/charlie.jpeg"
+      },
       "IsImposed": true,
       "createdAt": "2025-05-03"
     },
@@ -39,13 +30,11 @@
       "id": 3,
       "imposedCount": 2,
       "category": "저작권 침해",
-      "user": [
-        {
-          "id": 304,
-          "nickname": "daisy",
-          "img": "https://example.com/images/daisy.png"
-        }
-      ],
+      "user": {
+        "id": 304,
+        "nickname": "daisy",
+        "img": "https://example.com/images/daisy.png"
+      },
       "IsImposed": false,
       "createdAt": "2025-05-05"
     },
@@ -53,13 +42,11 @@
       "id": 4,
       "imposedCount": 7,
       "category": "개인정보 노출",
-      "user": [
-        {
-          "id": 305,
-          "nickname": "eve",
-          "img": "https://example.com/images/eve.jpg"
-        }
-      ],
+      "user": {
+        "id": 305,
+        "nickname": "eve",
+        "img": "https://example.com/images/eve.jpg"
+      },
       "IsImposed": true,
       "createdAt": "2025-05-07"
     },
@@ -67,18 +54,12 @@
       "id": 5,
       "imposedCount": 1,
       "category": "음란물 게시물",
-      "user": [
-        {
-          "id": 306,
-          "nickname": "frank",
-          "img": "https://example.com/images/frank.png"
-        },
-        {
-          "id": 307,
-          "nickname": "grace",
-          "img": "https://example.com/images/grace.jpeg"
-        }
-      ],
+      "user": {
+        "id": 306,
+        "nickname": "frank",
+        "img": "https://example.com/images/frank.png"
+      },
+
       "IsImposed": false,
       "createdAt": "2025-05-09"
     },
@@ -86,13 +67,11 @@
       "id": 6,
       "imposedCount": 4,
       "category": "사칭 계정",
-      "user": [
-        {
-          "id": 308,
-          "nickname": "henry",
-          "img": "https://example.com/images/henry.jpg"
-        }
-      ],
+      "user": {
+        "id": 308,
+        "nickname": "henry",
+        "img": "https://example.com/images/henry.jpg"
+      },
       "IsImposed": true,
       "createdAt": "2025-05-11"
     },
@@ -100,18 +79,12 @@
       "id": 7,
       "imposedCount": 6,
       "category": "허위 정보 유포",
-      "user": [
-        {
-          "id": 309,
-          "nickname": "iris",
-          "img": "https://example.com/images/iris.png"
-        },
-        {
-          "id": 310,
-          "nickname": "jack",
-          "img": "https://example.com/images/jack.jpg"
-        }
-      ],
+      "user": {
+        "id": 309,
+        "nickname": "iris",
+        "img": "https://example.com/images/iris.png"
+      },
+
       "IsImposed": false,
       "createdAt": "2025-05-13"
     },
@@ -119,13 +92,11 @@
       "id": 8,
       "imposedCount": 2,
       "category": "불법 광고",
-      "user": [
-        {
-          "id": 311,
-          "nickname": "kate",
-          "img": "https://example.com/images/kate.jpeg"
-        }
-      ],
+      "user": {
+        "id": 311,
+        "nickname": "kate",
+        "img": "https://example.com/images/kate.jpeg"
+      },
       "IsImposed": true,
       "createdAt": "2025-05-15"
     },
@@ -133,13 +104,11 @@
       "id": 9,
       "imposedCount": 8,
       "category": "명예 훼손",
-      "user": [
-        {
-          "id": 312,
-          "nickname": "leo",
-          "img": "https://example.com/images/leo.png"
-        }
-      ],
+      "user": {
+        "id": 312,
+        "nickname": "leo",
+        "img": "https://example.com/images/leo.png"
+      },
       "IsImposed": true,
       "createdAt": "2025-05-17"
     },
@@ -147,18 +116,11 @@
       "id": 10,
       "imposedCount": 3,
       "category": "폭력/위협",
-      "user": [
-        {
-          "id": 313,
-          "nickname": "maria",
-          "img": "https://example.com/images/maria.jpg"
-        },
-        {
-          "id": 314,
-          "nickname": "nate",
-          "img": "https://example.com/images/nate.png"
-        }
-      ],
+      "user": {
+        "id": 314,
+        "nickname": "nate",
+        "img": "https://example.com/images/nate.png"
+      },
       "IsImposed": false,
       "createdAt": "2025-05-19"
     }

--- a/src/mock/mockReports.json
+++ b/src/mock/mockReports.json
@@ -1,0 +1,166 @@
+{
+  "success": true,
+  "message": "성공적으로 처리되었습니다.",
+  "data": [
+    {
+      "id": 1,
+      "imposedCount": 3,
+      "category": "스팸 신고",
+      "user": [
+        {
+          "id": 301,
+          "nickname": "alice",
+          "img": "https://example.com/images/alice.png"
+        }
+      ],
+      "IsImposed": false,
+      "createdAt": "2025-05-01T10:15:00+09:00"
+    },
+    {
+      "id": 2,
+      "imposedCount": 5,
+      "category": "욕설/비방",
+      "user": [
+        {
+          "id": 302,
+          "nickname": "bob",
+          "img": "https://example.com/images/bob.jpg"
+        },
+        {
+          "id": 303,
+          "nickname": "charlie",
+          "img": "https://example.com/images/charlie.jpeg"
+        }
+      ],
+      "IsImposed": true,
+      "createdAt": "2025-05-03T14:30:00+09:00"
+    },
+    {
+      "id": 3,
+      "imposedCount": 2,
+      "category": "저작권 침해",
+      "user": [
+        {
+          "id": 304,
+          "nickname": "daisy",
+          "img": "https://example.com/images/daisy.png"
+        }
+      ],
+      "IsImposed": false,
+      "createdAt": "2025-05-05T09:45:00+09:00"
+    },
+    {
+      "id": 4,
+      "imposedCount": 7,
+      "category": "개인정보 노출",
+      "user": [
+        {
+          "id": 305,
+          "nickname": "eve",
+          "img": "https://example.com/images/eve.jpg"
+        }
+      ],
+      "IsImposed": true,
+      "createdAt": "2025-05-07T16:20:00+09:00"
+    },
+    {
+      "id": 5,
+      "imposedCount": 1,
+      "category": "음란물 게시물",
+      "user": [
+        {
+          "id": 306,
+          "nickname": "frank",
+          "img": "https://example.com/images/frank.png"
+        },
+        {
+          "id": 307,
+          "nickname": "grace",
+          "img": "https://example.com/images/grace.jpeg"
+        }
+      ],
+      "IsImposed": false,
+      "createdAt": "2025-05-09T11:10:00+09:00"
+    },
+    {
+      "id": 6,
+      "imposedCount": 4,
+      "category": "사칭 계정",
+      "user": [
+        {
+          "id": 308,
+          "nickname": "henry",
+          "img": "https://example.com/images/henry.jpg"
+        }
+      ],
+      "IsImposed": true,
+      "createdAt": "2025-05-11T13:55:00+09:00"
+    },
+    {
+      "id": 7,
+      "imposedCount": 6,
+      "category": "허위 정보 유포",
+      "user": [
+        {
+          "id": 309,
+          "nickname": "iris",
+          "img": "https://example.com/images/iris.png"
+        },
+        {
+          "id": 310,
+          "nickname": "jack",
+          "img": "https://example.com/images/jack.jpg"
+        }
+      ],
+      "IsImposed": false,
+      "createdAt": "2025-05-13T18:05:00+09:00"
+    },
+    {
+      "id": 8,
+      "imposedCount": 2,
+      "category": "불법 광고",
+      "user": [
+        {
+          "id": 311,
+          "nickname": "kate",
+          "img": "https://example.com/images/kate.jpeg"
+        }
+      ],
+      "IsImposed": true,
+      "createdAt": "2025-05-15T08:25:00+09:00"
+    },
+    {
+      "id": 9,
+      "imposedCount": 8,
+      "category": "명예 훼손",
+      "user": [
+        {
+          "id": 312,
+          "nickname": "leo",
+          "img": "https://example.com/images/leo.png"
+        }
+      ],
+      "IsImposed": true,
+      "createdAt": "2025-05-17T12:40:00+09:00"
+    },
+    {
+      "id": 10,
+      "imposedCount": 3,
+      "category": "폭력/위협",
+      "user": [
+        {
+          "id": 313,
+          "nickname": "maria",
+          "img": "https://example.com/images/maria.jpg"
+        },
+        {
+          "id": 314,
+          "nickname": "nate",
+          "img": "https://example.com/images/nate.png"
+        }
+      ],
+      "IsImposed": false,
+      "createdAt": "2025-05-19T20:15:00+09:00"
+    }
+  ]
+}

--- a/src/mock/mockReports.json
+++ b/src/mock/mockReports.json
@@ -11,7 +11,7 @@
         "nickname": "alice",
         "img": "https://example.com/images/alice.png"
       },
-      "IsImposed": false,
+      "isImposed": false,
       "createdAt": "2025-05-01"
     },
     {
@@ -23,7 +23,7 @@
         "nickname": "charlie",
         "img": "https://example.com/images/charlie.jpeg"
       },
-      "IsImposed": true,
+      "isImposed": true,
       "createdAt": "2025-05-03"
     },
     {
@@ -35,7 +35,7 @@
         "nickname": "daisy",
         "img": "https://example.com/images/daisy.png"
       },
-      "IsImposed": false,
+      "isImposed": false,
       "createdAt": "2025-05-05"
     },
     {
@@ -47,7 +47,7 @@
         "nickname": "eve",
         "img": "https://example.com/images/eve.jpg"
       },
-      "IsImposed": true,
+      "isImposed": true,
       "createdAt": "2025-05-07"
     },
     {
@@ -60,7 +60,7 @@
         "img": "https://example.com/images/frank.png"
       },
 
-      "IsImposed": false,
+      "isImposed": false,
       "createdAt": "2025-05-09"
     },
     {
@@ -72,7 +72,7 @@
         "nickname": "henry",
         "img": "https://example.com/images/henry.jpg"
       },
-      "IsImposed": true,
+      "isImposed": true,
       "createdAt": "2025-05-11"
     },
     {
@@ -85,7 +85,7 @@
         "img": "https://example.com/images/iris.png"
       },
 
-      "IsImposed": false,
+      "isImposed": false,
       "createdAt": "2025-05-13"
     },
     {
@@ -97,7 +97,7 @@
         "nickname": "kate",
         "img": "https://example.com/images/kate.jpeg"
       },
-      "IsImposed": true,
+      "isImposed": true,
       "createdAt": "2025-05-15"
     },
     {
@@ -109,7 +109,7 @@
         "nickname": "leo",
         "img": "https://example.com/images/leo.png"
       },
-      "IsImposed": true,
+      "isImposed": true,
       "createdAt": "2025-05-17"
     },
     {
@@ -121,7 +121,7 @@
         "nickname": "nate",
         "img": "https://example.com/images/nate.png"
       },
-      "IsImposed": false,
+      "isImposed": false,
       "createdAt": "2025-05-19"
     }
   ]

--- a/src/mock/mockUsers.json
+++ b/src/mock/mockUsers.json
@@ -1,0 +1,151 @@
+{
+  "success": true,
+  "message": "성공적으로 처리되었습니다.",
+  "data": [
+    {
+      "id": 1,
+      "email": "alice@example.com",
+      "name": "Alice Kim",
+      "user": [
+        {
+          "id": 201,
+          "nickname": "alice",
+          "img": "https://example.com/images/alice.png"
+        }
+      ],
+      "createdAt": "2025-05-15T09:30:00+09:00"
+    },
+    {
+      "id": 2,
+      "email": "bob@example.com",
+      "name": "Bob Lee",
+      "user": [
+        {
+          "id": 202,
+          "nickname": "bob",
+          "img": "https://example.com/images/bob.jpg"
+        }
+      ],
+      "createdAt": "2025-05-16T11:45:00+09:00"
+    },
+    {
+      "id": 3,
+      "email": "charlie@example.com",
+      "name": "Charlie Park",
+      "user": [
+        {
+          "id": 203,
+          "nickname": "charlie",
+          "img": "https://example.com/images/charlie.jpeg"
+        },
+        {
+          "id": 204,
+          "nickname": "daisy",
+          "img": "https://example.com/images/daisy.png"
+        }
+      ],
+      "createdAt": "2025-05-17T14:20:00+09:00"
+    },
+    {
+      "id": 4,
+      "email": "daisy@example.com",
+      "name": "Daisy Choi",
+      "user": [
+        {
+          "id": 205,
+          "nickname": "daisy",
+          "img": "https://example.com/images/daisy.png"
+        }
+      ],
+      "createdAt": "2025-05-18T08:10:00+09:00"
+    },
+    {
+      "id": 5,
+      "email": "eve@example.com",
+      "name": "Eve Jung",
+      "user": [
+        {
+          "id": 206,
+          "nickname": "eve",
+          "img": "https://example.com/images/eve.jpg"
+        }
+      ],
+      "createdAt": "2025-05-19T17:50:00+09:00"
+    },
+    {
+      "id": 6,
+      "email": "frank@example.com",
+      "name": "Frank Han",
+      "user": [
+        {
+          "id": 207,
+          "nickname": "frank",
+          "img": "https://example.com/images/frank.png"
+        },
+        {
+          "id": 208,
+          "nickname": "grace",
+          "img": "https://example.com/images/grace.jpeg"
+        }
+      ],
+      "createdAt": "2025-05-20T12:05:00+09:00"
+    },
+    {
+      "id": 7,
+      "email": "grace@example.com",
+      "name": "Grace Yoon",
+      "user": [
+        {
+          "id": 209,
+          "nickname": "grace",
+          "img": "https://example.com/images/grace.jpeg"
+        }
+      ],
+      "createdAt": "2025-05-21T10:15:00+09:00"
+    },
+    {
+      "id": 8,
+      "email": "henry@example.com",
+      "name": "Henry Shin",
+      "user": [
+        {
+          "id": 210,
+          "nickname": "henry",
+          "img": "https://example.com/images/henry.jpg"
+        }
+      ],
+      "createdAt": "2025-05-22T13:40:00+09:00"
+    },
+    {
+      "id": 9,
+      "email": "iris@example.com",
+      "name": "Iris Lim",
+      "user": [
+        {
+          "id": 211,
+          "nickname": "iris",
+          "img": "https://example.com/images/iris.png"
+        }
+      ],
+      "createdAt": "2025-05-23T16:25:00+09:00"
+    },
+    {
+      "id": 10,
+      "email": "jack@example.com",
+      "name": "Jack Han",
+      "user": [
+        {
+          "id": 212,
+          "nickname": "jack",
+          "img": "https://example.com/images/jack.jpg"
+        },
+        {
+          "id": 213,
+          "nickname": "kate",
+          "img": "https://example.com/images/kate.jpeg"
+        }
+      ],
+      "createdAt": "2025-05-24T19:55:00+09:00"
+    }
+  ]
+}

--- a/src/mock/mockUsers.json
+++ b/src/mock/mockUsers.json
@@ -6,146 +6,112 @@
       "id": 1,
       "email": "alice@example.com",
       "name": "Alice Kim",
-      "user": [
-        {
-          "id": 201,
-          "nickname": "alice",
-          "img": "https://example.com/images/alice.png"
-        }
-      ],
-      "createdAt": "2025-05-15T09:30:00+09:00"
+      "user": {
+        "id": 201,
+        "nickname": "alice",
+        "img": ""
+      },
+      "createdAt": "2025-05-15"
     },
     {
       "id": 2,
       "email": "bob@example.com",
       "name": "Bob Lee",
-      "user": [
-        {
-          "id": 202,
-          "nickname": "bob",
-          "img": "https://example.com/images/bob.jpg"
-        }
-      ],
-      "createdAt": "2025-05-16T11:45:00+09:00"
+      "user": {
+        "id": 202,
+        "nickname": "bob",
+        "img": ""
+      },
+      "createdAt": "2025-05-16"
     },
     {
       "id": 3,
       "email": "charlie@example.com",
       "name": "Charlie Park",
-      "user": [
-        {
-          "id": 203,
-          "nickname": "charlie",
-          "img": "https://example.com/images/charlie.jpeg"
-        },
-        {
-          "id": 204,
-          "nickname": "daisy",
-          "img": "https://example.com/images/daisy.png"
-        }
-      ],
-      "createdAt": "2025-05-17T14:20:00+09:00"
+      "user": {
+        "id": 204,
+        "nickname": "daisy",
+        "img": ""
+      },
+      "createdAt": "2025-05-17"
     },
     {
       "id": 4,
       "email": "daisy@example.com",
       "name": "Daisy Choi",
-      "user": [
-        {
-          "id": 205,
-          "nickname": "daisy",
-          "img": "https://example.com/images/daisy.png"
-        }
-      ],
-      "createdAt": "2025-05-18T08:10:00+09:00"
+      "user": {
+        "id": 205,
+        "nickname": "daisy",
+        "img": ""
+      },
+      "createdAt": "2025-05-18"
     },
     {
       "id": 5,
       "email": "eve@example.com",
       "name": "Eve Jung",
-      "user": [
-        {
-          "id": 206,
-          "nickname": "eve",
-          "img": "https://example.com/images/eve.jpg"
-        }
-      ],
-      "createdAt": "2025-05-19T17:50:00+09:00"
+      "user": {
+        "id": 206,
+        "nickname": "eve",
+        "img": ""
+      },
+      "createdAt": "2025-05-19"
     },
     {
       "id": 6,
       "email": "frank@example.com",
       "name": "Frank Han",
-      "user": [
-        {
-          "id": 207,
-          "nickname": "frank",
-          "img": "https://example.com/images/frank.png"
-        },
-        {
-          "id": 208,
-          "nickname": "grace",
-          "img": "https://example.com/images/grace.jpeg"
-        }
-      ],
-      "createdAt": "2025-05-20T12:05:00+09:00"
+      "user": {
+        "id": 208,
+        "nickname": "grace",
+        "img": ""
+      },
+      "createdAt": "2025-05-20"
     },
     {
       "id": 7,
       "email": "grace@example.com",
       "name": "Grace Yoon",
-      "user": [
-        {
-          "id": 209,
-          "nickname": "grace",
-          "img": "https://example.com/images/grace.jpeg"
-        }
-      ],
-      "createdAt": "2025-05-21T10:15:00+09:00"
+      "user": {
+        "id": 209,
+        "nickname": "grace",
+        "img": ""
+      },
+      "createdAt": "2025-05-21"
     },
     {
       "id": 8,
       "email": "henry@example.com",
       "name": "Henry Shin",
-      "user": [
-        {
-          "id": 210,
-          "nickname": "henry",
-          "img": "https://example.com/images/henry.jpg"
-        }
-      ],
-      "createdAt": "2025-05-22T13:40:00+09:00"
+      "user": {
+        "id": 210,
+        "nickname": "henry",
+        "img": ""
+      },
+      "createdAt": "2025-05-22"
     },
     {
       "id": 9,
       "email": "iris@example.com",
       "name": "Iris Lim",
-      "user": [
-        {
-          "id": 211,
-          "nickname": "iris",
-          "img": "https://example.com/images/iris.png"
-        }
-      ],
-      "createdAt": "2025-05-23T16:25:00+09:00"
+      "user": {
+        "id": 211,
+        "nickname": "iris",
+        "img": ""
+      },
+      "createdAt": "2025-05-23"
     },
     {
       "id": 10,
       "email": "jack@example.com",
       "name": "Jack Han",
-      "user": [
-        {
-          "id": 212,
-          "nickname": "jack",
-          "img": "https://example.com/images/jack.jpg"
-        },
-        {
-          "id": 213,
-          "nickname": "kate",
-          "img": "https://example.com/images/kate.jpeg"
-        }
-      ],
-      "createdAt": "2025-05-24T19:55:00+09:00"
+      "user": {
+        "id": 212,
+        "nickname": "jack",
+        "img": ""
+      },
+
+      "createdAt": "2025-05-24"
     }
   ]
 }

--- a/src/mock/mypage.ts
+++ b/src/mock/mypage.ts
@@ -6,7 +6,7 @@ import mockMypageJoinedProjectListData from './mockMypageJoinedProjectListData.j
 import mockMypageAppliedProjectListData from './mockMypageAppliedProjectListData.json';
 
 export const myPageProfile = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/user/me`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}user/me`,
   () => {
     return HttpResponse.json(mockMypageProfileData, {
       status: 200,
@@ -15,7 +15,7 @@ export const myPageProfile = http.get(
 );
 
 export const myPagePositionTag = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/position-tag`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}position-tag`,
   () => {
     return HttpResponse.json(mockPositionTagData, {
       status: 200,
@@ -24,7 +24,7 @@ export const myPagePositionTag = http.get(
 );
 
 export const myPageSkillTag = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/skill-tag`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}skill-tag`,
   () => {
     return HttpResponse.json(mockSkillTagData, {
       status: 200,
@@ -33,7 +33,7 @@ export const myPageSkillTag = http.get(
 );
 
 export const myPageJoinedProjectList = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/user/me/project`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}user/me/project`,
   () => {
     return HttpResponse.json(mockMypageJoinedProjectListData, {
       status: 200,
@@ -42,7 +42,7 @@ export const myPageJoinedProjectList = http.get(
 );
 
 export const myPageAppliedProjectList = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/user/me/applications`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}user/me/applications`,
   () => {
     return HttpResponse.json(mockMypageAppliedProjectListData, {
       status: 200,
@@ -51,7 +51,7 @@ export const myPageAppliedProjectList = http.get(
 );
 
 export const mypageEditProfile = http.put(
-  `${import.meta.env.VITE_API_BASE_URL}/user/me`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}user/me`,
   () => {
     return HttpResponse.json({
       status: 200,

--- a/src/mock/projectDetail.ts
+++ b/src/mock/projectDetail.ts
@@ -1,11 +1,19 @@
 import { http, HttpResponse } from 'msw';
 import mockPrjectDetail from './mockProjectDetail.json';
+import mockReports from './mockReports.json';
 
 export const projectDetail = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/project/:projectId`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}/project/:projectId`,
   () => {
     return HttpResponse.json(mockPrjectDetail, {
       status: 200,
     });
+  }
+);
+
+export const reportsAll = http.get(
+  `${import.meta.env.VITE_APP_API_BASE_URL}reports`,
+  () => {
+    return HttpResponse.json(mockReports, { status: 200 });
   }
 );

--- a/src/mock/projectDetail.ts
+++ b/src/mock/projectDetail.ts
@@ -3,7 +3,7 @@ import mockPrjectDetail from './mockProjectDetail.json';
 import mockReports from './mockReports.json';
 
 export const projectDetail = http.get(
-  `${import.meta.env.VITE_APP_API_BASE_URL}/project/:projectId`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}project/:projectId`,
   () => {
     return HttpResponse.json(mockPrjectDetail, {
       status: 200,

--- a/src/mock/projectLists.ts
+++ b/src/mock/projectLists.ts
@@ -3,7 +3,7 @@ import count from './mockCount.json';
 import project from './mockProject.json';
 
 export const fetchProjectLists = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/project`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}project`,
   () => {
     return HttpResponse.json(project, {
       status: 200,
@@ -12,7 +12,7 @@ export const fetchProjectLists = http.get(
 );
 
 export const fetchProjectStatistic = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/project/count`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}project/count`,
   () => {
     return HttpResponse.json(count, {
       status: 200,

--- a/src/mock/projectSearchFiltering.ts
+++ b/src/mock/projectSearchFiltering.ts
@@ -4,7 +4,7 @@ import position from './mockPosition.json';
 import method from './mockMethod.json';
 
 export const fetchSkillTag = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/skill-tag`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}skill-tag`,
   () => {
     return HttpResponse.json(skill, {
       status: 200,
@@ -12,7 +12,7 @@ export const fetchSkillTag = http.get(
   }
 );
 export const fetchPositionTag = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/position-tag`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}position-tag`,
   () => {
     return HttpResponse.json(position, {
       status: 200,
@@ -21,7 +21,7 @@ export const fetchPositionTag = http.get(
 );
 
 export const fetchMethodTag = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/method`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}method`,
   () => {
     return HttpResponse.json(method, {
       status: 200,

--- a/src/mock/userpage.ts
+++ b/src/mock/userpage.ts
@@ -1,9 +1,10 @@
 import { http, HttpResponse } from 'msw';
 import mockUserpageProfileData from './mockUserpageProfileData.json';
 import mockUserpageAppliedProjectListData from './mockUserpageAppliedProjectListData.json';
+import mockUsers from './mockUsers.json';
 
 export const userPageProfile = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/user/:id`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}user/:id`,
   () => {
     return HttpResponse.json(mockUserpageProfileData, {
       status: 200,
@@ -12,10 +13,17 @@ export const userPageProfile = http.get(
 );
 
 export const userPageAppliedProjectList = http.get(
-  `${import.meta.env.VITE_API_BASE_URL}/user/:id/project`,
+  `${import.meta.env.VITE_APP_API_BASE_URL}user/:id/project`,
   () => {
     return HttpResponse.json(mockUserpageAppliedProjectListData, {
       status: 200,
     });
+  }
+);
+
+export const userAll = http.get(
+  `${import.meta.env.VITE_APP_API_BASE_URL}users`,
+  () => {
+    return HttpResponse.json(mockUsers, { status: 200 });
   }
 );

--- a/src/models/activityLog.ts
+++ b/src/models/activityLog.ts
@@ -1,6 +1,7 @@
-import type { ApiCommonType } from './apiCommon';
+import type { ApiCommonType, User } from './apiCommon';
 
 export interface MyInquiries {
+  id: number;
   title: string;
   content: string;
   category: string;
@@ -10,6 +11,14 @@ export interface MyInquiries {
 
 export interface ApiMyInquiries extends ApiCommonType {
   data: MyInquiries[];
+}
+export interface AllInquiries extends MyInquiries {
+  user: User;
+  createdAt: string;
+}
+
+export interface ApiAllInquiries extends ApiCommonType {
+  data: AllInquiries[];
 }
 
 export interface MyComments {

--- a/src/models/activityLog.ts
+++ b/src/models/activityLog.ts
@@ -1,4 +1,4 @@
-import type { ApiCommonType, User } from './apiCommon';
+import type { ApiCommonType } from './apiCommon';
 
 export interface MyInquiries {
   id: number;
@@ -11,14 +11,6 @@ export interface MyInquiries {
 
 export interface ApiMyInquiries extends ApiCommonType {
   data: MyInquiries[];
-}
-export interface AllInquiries extends MyInquiries {
-  user: User;
-  createdAt: string;
-}
-
-export interface ApiAllInquiries extends ApiCommonType {
-  data: AllInquiries[];
 }
 
 export interface MyComments {

--- a/src/models/admin/mainPreview.ts
+++ b/src/models/admin/mainPreview.ts
@@ -1,0 +1,11 @@
+import type { MyInquiries } from '../activityLog';
+import type { ApiCommonType, User } from '../apiCommon';
+
+export interface AllInquiries extends MyInquiries {
+  user: User;
+  createdAt: string;
+}
+
+export interface ApiAllInquiries extends ApiCommonType {
+  data: AllInquiries[];
+}

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -1,5 +1,4 @@
-//model
-import { ApiCommonType, User } from './apiCommon';
+import { type ApiCommonType, type User } from './apiCommon';
 
 export interface VerifyEmail {
   email: string;

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -35,7 +35,6 @@ export interface ApiGetAllUsers extends ApiCommonType {
 export interface AllUser {
   id: number;
   email: string;
-  name: string;
   user: User;
   createdAt: string;
 }

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -1,5 +1,5 @@
 //model
-import { ApiCommonType } from './apiCommon';
+import { ApiCommonType, User } from './apiCommon';
 
 export interface VerifyEmail {
   email: string;
@@ -26,4 +26,16 @@ export interface UserData {
 export interface ApiOauth extends ApiCommonType {
   data: Pick<LoginResponse, 'accessToken'>;
   user: UserData;
+}
+
+export interface ApiGetAllUsers extends ApiCommonType {
+  data: AllUser[];
+}
+
+export interface AllUser {
+  id: number;
+  email: string;
+  name: string;
+  user: User;
+  createdAt: string;
 }

--- a/src/models/report.ts
+++ b/src/models/report.ts
@@ -1,6 +1,21 @@
+import { ApiCommonType, User } from './apiCommon';
+
 export interface ApiPostContent {
   reportTargetId: number;
   reportFilter: number;
   reason: string[];
   detail: string;
+}
+
+export interface ApiAllReports extends ApiCommonType {
+  data: AllReports[];
+}
+
+export interface AllReports {
+  id: number;
+  imposedCount: number;
+  category: string;
+  user: User;
+  IsImposed: boolean;
+  createdAt: string;
 }

--- a/src/models/report.ts
+++ b/src/models/report.ts
@@ -1,4 +1,4 @@
-import { ApiCommonType, User } from './apiCommon';
+import { type ApiCommonType, type User } from './apiCommon';
 
 export interface ApiPostContent {
   reportTargetId: number;

--- a/src/models/report.ts
+++ b/src/models/report.ts
@@ -16,6 +16,6 @@ export interface AllReports {
   imposedCount: number;
   category: string;
   user: User;
-  IsImposed: boolean;
+  isImposed: boolean;
   createdAt: string;
 }

--- a/src/pages/admin/adminMain/AdminMain.styled.ts
+++ b/src/pages/admin/adminMain/AdminMain.styled.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  padding: 50px;
+  padding: 10px;
   min-height: 100vh;
 `;
 
@@ -9,7 +9,17 @@ export const Wrapper = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-auto-rows: minmax(350px, auto);
-  gap: 20px;
+  gap: 10px;
+
+  & > * {
+    width: 100%;
+  }
+
+  & > *:nth-child(4) {
+    grid-column: 1 / 3;
+    width: 300px;
+    width: 100%;
+  }
 
   @media (max-width: 768px) {
     grid-template-columns: 1fr;

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -5,10 +5,7 @@ import useAuthStore from '../store/authStore';
 import ProtectRoute from '../components/common/ProtectRoute';
 import NotFoundPage from '../pages/notFoundPage/NotFoundPage';
 import QueryErrorBoundary from '../components/common/error/QueryErrorBoundary';
-import { ToastProvider } from '../components/common/Toast/ToastProvider';
-import NotificationInitializer from '../components/user/notificationLive/NotificationInitializer';
-import { NotificationProvider } from '../components/user/notificationLive/NotificationProvider';
-import { ADMIN_ROUTE, ROUTES } from '../constants/routes';
+import { ROUTES } from '../constants/routes';
 const Login = lazy(() => import('../pages/login/Login'));
 const LoginSuccess = lazy(() => import('../pages/login/LoginSuccess'));
 const LoginApi = lazy(() => import('../pages/login/LoginApi'));
@@ -379,22 +376,7 @@ export const AppRoutes = () => {
     };
   });
 
-  const router = createBrowserRouter([
-    {
-      element: (
-        <NotificationProvider>
-          <ToastProvider>
-            <NotificationInitializer />
-            <Outlet />
-          </ToastProvider>
-        </NotificationProvider>
-      ),
-
-      children: [...newRouteList, { path: '*', element: <NotFoundPage /> }],
-    },
-  ]);
-
-  return <RouterProvider router={router} />;
+  return newRouteList;
 };
 
 export default AppRoutes;

--- a/src/routes/MergeRoutes.tsx
+++ b/src/routes/MergeRoutes.tsx
@@ -4,14 +4,19 @@ import AppRoutes from './AppRoutes';
 import NotFoundPage from '../pages/notFoundPage/NotFoundPage';
 import { ToastProvider } from '../components/common/Toast/ToastProvider';
 import ProtectAdminRoute from './ProtectAdminRoute';
+import { NotificationProvider } from '../components/user/notificationLive/NotificationProvider';
+import NotificationInitializer from '../components/user/notificationLive/NotificationInitializer';
 
 export default function MergeRoutes() {
   const router = createBrowserRouter([
     {
       element: (
-        <ToastProvider>
-          <Outlet />
-        </ToastProvider>
+        <NotificationProvider>
+          <NotificationInitializer />
+          <ToastProvider>
+            <Outlet />
+          </ToastProvider>
+        </NotificationProvider>
       ),
       children: [...AppRoutes()],
     },


### PR DESCRIPTION
### 구현내용

- 관리자 메인 페이지 구현
- "전체 회원 조회" 미리보기 컴포넌트 구현(API 미구현으로 현재 mock 데이터 연결)
- "문의 항목 전체 조회" 미리 보기 컴포넌트 구현(API 연결 구현)
- "신고 전체 조회" 미리보기 컴포넌트 구현(API 미구현으로 현재 mock 데이터 연결)
- 일일 방문 횟수 그래프화
- "공지사항 전체 조회" 미리보기 컴포넌트 구현(API 연결 구현)

![image](https://github.com/user-attachments/assets/18561fa1-e2ee-4cd8-b021-8bc767873e20)


### 연관이슈

close #318 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
  - 관리자 메인 페이지에 방문자 그래프 카드, 전체 사용자 미리보기, 문의 미리보기, 신고 미리보기 컴포넌트가 추가되었습니다.
  - 관리자 미리보기 카드에서 각 항목을 클릭하여 상세 페이지로 이동할 수 있습니다.
  - 전체 사용자, 문의, 신고 데이터를 조회하는 API 연동 및 관련 훅이 추가되었습니다.

- **스타일**
  - 관리자 메인 및 미리보기 카드 UI가 새롭게 스타일링되었습니다.

- **버그 수정**
  - 문의 카드 키 이름 오타 수정 및 중복 항목 제거 등 카드 리스트 정렬이 개선되었습니다.

- **기타**
  - 목업 데이터 및 API 환경변수 명칭이 일관성 있게 변경되었습니다.
  - 공지 미리보기, 로딩 및 빈 데이터 처리 UI가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->