### PR TITLE
관리자 "회원 전체 조회" 페이지 구현 ( issue #330 )

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -106,6 +106,16 @@ export const getOauthLogin = async (oauthAccessToken: string) => {
   }
 };
 
+export const getAllUsersPreview = async () => {
+  try {
+    const response = await httpClient.get<ApiGetAllUsers>(`/users/preview`);
+    return response.data.data;
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};
+
 export const getAllUsers = async () => {
   try {
     const response = await httpClient.get<ApiGetAllUsers>(`/users`);

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -9,7 +9,7 @@ import { httpClient } from './http.api';
 import { loginFormValues } from '../pages/login/Login';
 import { registerFormValues } from '../pages/user/register/Register';
 import { changePasswordFormValues } from '../pages/user/changePassword/ChangePassword';
-import { SearchType } from '../models/search';
+import { type SearchType } from '../models/search';
 
 export const postVerificationEmail = async (email: string) => {
   try {

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,5 +1,6 @@
 import {
   ApiGetAllUsers,
+  ApiGetAllUsersPreview,
   type ApiOauth,
   type ApiVerifyNickname,
   type VerifyEmail,
@@ -108,7 +109,9 @@ export const getOauthLogin = async (oauthAccessToken: string) => {
 
 export const getAllUsersPreview = async () => {
   try {
-    const response = await httpClient.get<ApiGetAllUsers>(`/users/preview`);
+    const response = await httpClient.get<ApiGetAllUsersPreview>(
+      `/users/preview`
+    );
     return response.data.data;
   } catch (e) {
     console.error(e);

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -9,6 +9,7 @@ import { httpClient } from './http.api';
 import { loginFormValues } from '../pages/login/Login';
 import { registerFormValues } from '../pages/user/register/Register';
 import { changePasswordFormValues } from '../pages/user/changePassword/ChangePassword';
+import { SearchType } from '../models/search';
 
 export const postVerificationEmail = async (email: string) => {
   try {
@@ -119,9 +120,9 @@ export const getAllUsersPreview = async () => {
   }
 };
 
-export const getAllUsers = async () => {
+export const getAllUsers = async (params: SearchType) => {
   try {
-    const response = await httpClient.get<ApiGetAllUsers>(`/users`);
+    const response = await httpClient.get<ApiGetAllUsers>(`/users`, { params });
     return response.data.data;
   } catch (e) {
     console.error(e);

--- a/src/components/admin/adminNotice/AdminNoticeList.tsx
+++ b/src/components/admin/adminNotice/AdminNoticeList.tsx
@@ -25,7 +25,7 @@ export default function AdminNoticeList() {
 
   return (
     <>
-      <SearchBar onGetKeyword={handleGetKeyword} />
+      <SearchBar onGetKeyword={handleGetKeyword} isNotice={true} />
       <S.NoticeItemWrapper>
         <NoticeItem
           noticeData={noticeData.notices}

--- a/src/components/admin/adminNotice/AdminNoticeList.tsx
+++ b/src/components/admin/adminNotice/AdminNoticeList.tsx
@@ -25,7 +25,11 @@ export default function AdminNoticeList() {
 
   return (
     <>
-      <SearchBar onGetKeyword={handleGetKeyword} isNotice={true} />
+      <SearchBar
+        onGetKeyword={handleGetKeyword}
+        value={value}
+        isNotice={true}
+      />
       <S.NoticeItemWrapper>
         <NoticeItem
           noticeData={noticeData.notices}

--- a/src/components/admin/adminNotice/AdminNoticeList.tsx
+++ b/src/components/admin/adminNotice/AdminNoticeList.tsx
@@ -1,38 +1,15 @@
-import { useEffect, useState } from 'react';
 import SearchBar from '../../../components/common/admin/searchBar/SearchBar';
 import * as S from './AdminNoticeList.styled';
-import type { NoticeSearch } from '../../../models/customerService';
 import { useGetNotice } from '../../../hooks/user/useGetNotice';
-import { useSearchParams } from 'react-router-dom';
 import Pagination from '../../../components/common/pagination/Pagination';
 import Spinner from '../../../components/user/mypage/Spinner';
 import NoticeItem from '../../../pages/user/customerService/notice/noticeItem/NoticeItem';
+import useSearchBar from '../../../hooks/admin/useSearchBar';
 
 export default function AdminNoticeList() {
-  const [noticeSearch, setNoticeSearch] = useState<NoticeSearch>({
-    keyword: '',
-    page: 1,
-  });
-  const [value, setValue] = useState<string>('');
-  const { noticeData, isLoading } = useGetNotice(noticeSearch);
-  const [searchParams] = useSearchParams();
-
-  useEffect(() => {
-    const searchKeyword = searchParams.get('keyword');
-
-    if (searchKeyword) {
-      setNoticeSearch((prev) => ({ ...prev, keyword: searchKeyword }));
-      setValue((prev) => (searchKeyword ? searchKeyword : prev));
-    }
-  }, [searchParams]);
-
-  const handleGetKeyword = (keyword: string) => {
-    setNoticeSearch((prev) => ({ ...prev, keyword }));
-    setValue(keyword);
-  };
-  const handleChangePagination = (page: number) => {
-    setNoticeSearch((prev) => ({ ...prev, page }));
-  };
+  const { searchUnit, value, handleGetKeyword, handleChangePagination } =
+    useSearchBar();
+  const { noticeData, isLoading } = useGetNotice(searchUnit);
 
   if (isLoading) {
     return (
@@ -48,7 +25,7 @@ export default function AdminNoticeList() {
 
   return (
     <>
-      <SearchBar onGetKeyword={handleGetKeyword} value={value} />
+      <SearchBar onGetKeyword={handleGetKeyword} />
       <S.NoticeItemWrapper>
         <NoticeItem
           noticeData={noticeData.notices}
@@ -57,7 +34,7 @@ export default function AdminNoticeList() {
         />
       </S.NoticeItemWrapper>
       <Pagination
-        page={noticeSearch.page}
+        page={searchUnit.page}
         getLastPage={lastPage}
         onChangePagination={handleChangePagination}
       />

--- a/src/components/admin/mainCard/MainCard.styled.ts
+++ b/src/components/admin/mainCard/MainCard.styled.ts
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
-  border: 1px solid #ccc;
+  border: 1px solid ${({ theme }) => theme.color.grey};
   border-radius: ${({ theme }) => theme.borderRadius.primary};
 `;
 

--- a/src/components/admin/previewComponent/allUserPreview/AllUserPreview.tsx
+++ b/src/components/admin/previewComponent/allUserPreview/AllUserPreview.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import * as S from './AllUserPreview.styled';
-import { useGetAllUsers } from '../../../../hooks/admin/useGetAllUsers';
 import Avatar from '../../../common/avatar/Avatar';
 import { ADMIN_ROUTE } from '../../../../constants/routes';
 import arrow_right from '../../../../assets/ArrowRight.svg';
 import LoadingSpinner from '../../../common/loadingSpinner/LoadingSpinner';
+import { useGetAllUsersPreview } from '../../../../hooks/admin/useGetAllUsersPreview';
 
 const AllUserPreview = () => {
-  const { allUserData, isLoading, isFetching } = useGetAllUsers();
+  const { allUserData, isLoading, isFetching } = useGetAllUsersPreview();
 
   if (isLoading || isFetching) {
     return <LoadingSpinner />;
@@ -17,15 +17,9 @@ const AllUserPreview = () => {
     return <S.Container>가입된 회원이 없습니다.</S.Container>;
   }
 
-  const previewList = allUserData
-    ? allUserData.length > 6
-      ? allUserData.slice(0, 4)
-      : allUserData
-    : [];
-
   return (
     <S.Container>
-      {previewList?.map((user) => (
+      {allUserData?.map((user) => (
         <S.Wrapper key={user.id}>
           <S.UserArea>
             <Avatar image={user.user.img} size='40px' />

--- a/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.styled.ts
+++ b/src/components/admin/previewComponent/inquiresPreview/InquiresPreview.styled.ts
@@ -51,7 +51,8 @@ export const Divider = styled.p`
 
 export const InquiryState = styled.p<{ $isCompleted: boolean }>`
   font-size: 9px;
-  color: ${({ $isCompleted }) => ($isCompleted ? `#07DE00` : `#DE1A00`)};
+  color: ${({ theme, $isCompleted }) =>
+    $isCompleted ? theme.color.green : theme.color.red};
 `;
 
 export const MoveToInquiryArea = styled(Link)`

--- a/src/components/admin/previewComponent/reportsPreview/ReportsPreview.styled.ts
+++ b/src/components/admin/previewComponent/reportsPreview/ReportsPreview.styled.ts
@@ -21,7 +21,7 @@ export const ContentArea = styled.div`
   margin-left: 16px;
 `;
 
-export const ImposedCount = styled.div`
+export const ReportedCount = styled.div`
   font-size: 9px;
   opacity: 0.5;
 `;
@@ -49,9 +49,9 @@ export const Divider = styled.p`
   margin-right: 3px;
 `;
 
-export const IsImposed = styled.p<{ $isImposed: boolean }>`
+export const IsDone = styled.p<{ $isDone: boolean }>`
   font-size: 9px;
-  color: ${({ $isImposed }) => ($isImposed ? `#07DE00` : `#DE1A00`)};
+  color: ${({ $isDone }) => ($isDone ? `#07DE00` : `#DE1A00`)};
 `;
 
 export const MoveToReportsArea = styled(Link)`

--- a/src/components/admin/previewComponent/reportsPreview/ReportsPreview.styled.ts
+++ b/src/components/admin/previewComponent/reportsPreview/ReportsPreview.styled.ts
@@ -51,7 +51,8 @@ export const Divider = styled.p`
 
 export const IsDone = styled.p<{ $isDone: boolean }>`
   font-size: 9px;
-  color: ${({ $isDone }) => ($isDone ? `#07DE00` : `#DE1A00`)};
+  color: ${({ theme, $isDone }) =>
+    $isDone ? theme.color.green : theme.color.red};
 `;
 
 export const MoveToReportsArea = styled(Link)`

--- a/src/components/admin/previewComponent/reportsPreview/ReportsPreview.tsx
+++ b/src/components/admin/previewComponent/reportsPreview/ReportsPreview.tsx
@@ -20,14 +20,14 @@ const ReportsPreview = () => {
           <S.ReportArea to={`${ADMIN_ROUTE.reports}/${report.id}`}>
             <Avatar image={report.user.img} size='40px' />
             <S.ContentArea>
-              <S.ImposedCount>{report.imposedCount} 번</S.ImposedCount>
+              <S.ReportedCount>{report.reportedCount} 번</S.ReportedCount>
               <S.Category>{report.category}</S.Category>
               <S.StateArea>
                 <S.ReportDate>{report.createdAt}</S.ReportDate>
                 <S.Divider>|</S.Divider>
-                <S.IsImposed $isImposed={report.isImposed}>
-                  {report.isImposed ? '검토 완료' : '검토 미완료'}
-                </S.IsImposed>
+                <S.IsDone $isDone={report.isDone}>
+                  {report.isDone ? '검토 완료' : '검토 미완료'}
+                </S.IsDone>
               </S.StateArea>
             </S.ContentArea>
           </S.ReportArea>

--- a/src/components/admin/userCard/UserCard.styled.ts
+++ b/src/components/admin/userCard/UserCard.styled.ts
@@ -49,6 +49,7 @@ export const TextContent = styled.p<{
 export const SkillTagArea = styled.div`
   display: flex;
   gap: 4px;
+  margin-left: 15px;
 `;
 
 export const SkillTag = styled.img`

--- a/src/components/admin/userCard/UserCard.styled.ts
+++ b/src/components/admin/userCard/UserCard.styled.ts
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
+import { UserState } from '../../../models/auth';
 
 export const Container = styled.div`
   width: 240px;
   display: flex;
   flex-direction: column;
-  border: 1px solid #000000;
+  border: 1px solid ${({ theme }) => theme.color.white};
   border-radius: ${({ theme }) => theme.borderRadius.primary};
   padding: 10px;
 `;
@@ -32,17 +33,17 @@ export const TextLabel = styled.label`
 `;
 
 export const TextContent = styled.p<{
-  $userState?: '접속 중' | '오프라인' | '정지';
+  $userState?: UserState;
 }>`
   font-size: 14px;
-  color: ${({ $userState }) =>
-    $userState === '접속 중'
-      ? `#39E81E`
-      : $userState === '오프라인'
-      ? `#2560E8`
-      : $userState === '정지'
-      ? `#E8000C`
-      : `#000000`};
+  color: ${({ theme, $userState }) =>
+    $userState === UserState.ONLINE
+      ? theme.color.green
+      : $userState === UserState.OFFLINE
+      ? theme.color.blue
+      : $userState === UserState.SUSPENDED
+      ? theme.color.red
+      : theme.color.white};
   margin-left: 15px;
 `;
 
@@ -55,6 +56,6 @@ export const SkillTagArea = styled.div`
 export const SkillTag = styled.img`
   width: 29px;
   height: 29px;
-  border: 1px solid #ccc;
+  border: 1px solid ${({ theme }) => theme.color.grey};
   border-radius: 50%;
 `;

--- a/src/components/admin/userCard/UserCard.styled.ts
+++ b/src/components/admin/userCard/UserCard.styled.ts
@@ -5,7 +5,7 @@ export const Container = styled.div`
   width: 240px;
   display: flex;
   flex-direction: column;
-  border: 1px solid ${({ theme }) => theme.color.white};
+  border: 1px solid ${({ theme }) => theme.color.grey};
   border-radius: ${({ theme }) => theme.borderRadius.primary};
   padding: 10px;
 `;

--- a/src/components/admin/userCard/UserCard.styled.ts
+++ b/src/components/admin/userCard/UserCard.styled.ts
@@ -1,0 +1,59 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width: 240px;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #000000;
+  border-radius: ${({ theme }) => theme.borderRadius.primary};
+  padding: 10px;
+`;
+
+export const ProfileHeader = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const NickName = styled.p`
+  margin-top: 5px;
+`;
+
+export const MainContentArea = styled.div`
+  padding: 15px;
+`;
+
+export const TextLabel = styled.label`
+  display: inline-block;
+  font-size: 14px;
+  opacity: 0.3;
+  word-break: break-word;
+  white-space: pre-wrap;
+`;
+
+export const TextContent = styled.p<{
+  $userState?: '접속 중' | '오프라인' | '정지';
+}>`
+  font-size: 14px;
+  color: ${({ $userState }) =>
+    $userState === '접속 중'
+      ? `#39E81E`
+      : $userState === '오프라인'
+      ? `#2560E8`
+      : $userState === '정지'
+      ? `#E8000C`
+      : `#000000`};
+  margin-left: 15px;
+`;
+
+export const SkillTagArea = styled.div`
+  display: flex;
+  gap: 4px;
+`;
+
+export const SkillTag = styled.img`
+  width: 29px;
+  height: 29px;
+  border: 1px solid #ccc;
+  border-radius: 50%;
+`;

--- a/src/components/admin/userCard/UserCard.tsx
+++ b/src/components/admin/userCard/UserCard.tsx
@@ -17,10 +17,6 @@ const UserCard = ({ userData }: UserCardProps) => {
       <S.MainContentArea>
         <S.TextLabel>이메일</S.TextLabel>
         <S.TextContent>{userData.email}</S.TextContent>
-        <S.TextLabel>포지션</S.TextLabel>
-        <S.TextContent>
-          {userData.position.map((position) => position.name).join(', ')}
-        </S.TextContent>
         <S.TextLabel>회원 상태</S.TextLabel>
         <S.TextContent $userState={userData.userState}>
           {userData.userState}
@@ -31,14 +27,18 @@ const UserCard = ({ userData }: UserCardProps) => {
             ? '없음'
             : `${userData.reportedCount}번`}
         </S.TextContent>
-        <S.TextLabel>계정 생성 날짜</S.TextLabel>
-        <S.TextContent>{userData.createdAt}</S.TextContent>
+        <S.TextLabel>포지션</S.TextLabel>
+        <S.TextContent>
+          {userData.position.map((position) => position.name).join(', ')}
+        </S.TextContent>
         <S.TextLabel>대표 스킬</S.TextLabel>
         <S.SkillTagArea>
           {userData.skill.map((skillTag) => (
             <S.SkillTag src={skillTag.img} />
           ))}
         </S.SkillTagArea>
+        <S.TextLabel>계정 생성 날짜</S.TextLabel>
+        <S.TextContent>{userData.createdAt}</S.TextContent>
       </S.MainContentArea>
     </S.Container>
   );

--- a/src/components/admin/userCard/UserCard.tsx
+++ b/src/components/admin/userCard/UserCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as S from './UserCard.styled';
 import Avatar from '../../common/avatar/Avatar';
-import { AllUser } from '../../../models/auth';
+import { type AllUser } from '../../../models/auth';
 
 interface UserCardProps {
   userData: AllUser;
@@ -34,7 +34,7 @@ const UserCard = ({ userData }: UserCardProps) => {
         <S.TextLabel>대표 스킬</S.TextLabel>
         <S.SkillTagArea>
           {userData.skill.map((skillTag) => (
-            <S.SkillTag src={skillTag.img} />
+            <S.SkillTag key={skillTag.id} src={skillTag.img} />
           ))}
         </S.SkillTagArea>
         <S.TextLabel>계정 생성 날짜</S.TextLabel>

--- a/src/components/admin/userCard/UserCard.tsx
+++ b/src/components/admin/userCard/UserCard.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import * as S from './UserCard.styled';
+import Avatar from '../../common/avatar/Avatar';
+import { AllUser } from '../../../models/auth';
+
+interface UserCardProps {
+  userData: AllUser;
+}
+
+const UserCard = ({ userData }: UserCardProps) => {
+  return (
+    <S.Container>
+      <S.ProfileHeader>
+        <Avatar image={userData.user.img} size='46px' />
+        <S.NickName>{userData.user.nickname}</S.NickName>
+      </S.ProfileHeader>
+      <S.MainContentArea>
+        <S.TextLabel>이메일</S.TextLabel>
+        <S.TextContent>{userData.email}</S.TextContent>
+        <S.TextLabel>포지션</S.TextLabel>
+        <S.TextContent>
+          {userData.position.map((position) => position.name).join(', ')}
+        </S.TextContent>
+        <S.TextLabel>회원 상태</S.TextLabel>
+        <S.TextContent $userState={userData.userState}>
+          {userData.userState}
+        </S.TextContent>
+        <S.TextLabel>경고 횟수</S.TextLabel>
+        <S.TextContent>
+          {userData.reportedCount === 0
+            ? '없음'
+            : `${userData.reportedCount}번`}
+        </S.TextContent>
+        <S.TextLabel>계정 생성 날짜</S.TextLabel>
+        <S.TextContent>{userData.createdAt}</S.TextContent>
+        <S.TextLabel>대표 스킬</S.TextLabel>
+        <S.SkillTagArea>
+          {userData.skill.map((skillTag) => (
+            <S.SkillTag src={skillTag.img} />
+          ))}
+        </S.SkillTagArea>
+      </S.MainContentArea>
+    </S.Container>
+  );
+};
+
+export default UserCard;

--- a/src/components/common/admin/searchBar/SearchBar.styled.ts
+++ b/src/components/common/admin/searchBar/SearchBar.styled.ts
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+
+export const AdminSearchBarContainer = styled.form`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2rem;
+`;
+
+export const AdminSearchBarWrapper = styled.div`
+  display: flex;
+  width: 70%;
+  justify-content: space-between;
+  padding: 0.5rem 0.5rem 0.5rem 1rem;
+  border: 1px solid ${({ theme }) => theme.color.deepGrey};
+  border-radius: ${({ theme }) => theme.borderRadius.large} 0 0
+    ${({ theme }) => theme.borderRadius.large};
+`;
+
+export const AdminSearchBarInput = styled.input`
+  width: 100%;
+  font-size: 1.3rem;
+`;
+
+export const AdminSearchBarBackIcon = styled.button`
+  svg {
+    width: 1.5rem;
+  }
+`;
+
+export const AdminSearchBarButton = styled.button`
+  width: 10%;
+  border: 1px solid ${({ theme }) => theme.color.navy};
+  background: ${({ theme }) => theme.color.navy};
+  border-radius: 0 ${({ theme }) => theme.borderRadius.large}
+    ${({ theme }) => theme.borderRadius.large} 0;
+  font-size: 1.3rem;
+  color: ${({ theme }) => theme.color.white};
+  padding: 0.5rem 1rem 0.5rem 0.5rem;
+`;

--- a/src/components/common/admin/searchBar/SearchBar.tsx
+++ b/src/components/common/admin/searchBar/SearchBar.tsx
@@ -1,0 +1,75 @@
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import * as S from './SearchBar.styled';
+import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useModal } from '../../../../hooks/useModal';
+import { MODAL_MESSAGE_CUSTOMER_SERVICE } from '../../../../constants/user/customerService';
+import Modal from '../../modal/Modal';
+
+interface SearchBarProps {
+  onGetKeyword: (value: string) => void;
+  value: string;
+}
+
+export default function SearchBar({ onGetKeyword, value }: SearchBarProps) {
+  const [keyword, setKeyword] = useState<string>('');
+  const { isOpen, message, handleModalOpen, handleModalClose } = useModal();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const handleKeyword = (inputValue: string) => {
+    const newSearchParams = new URLSearchParams(searchParams);
+    if (inputValue === '') {
+      newSearchParams.delete('keyword');
+    } else {
+      newSearchParams.set('keyword', inputValue);
+    }
+    setSearchParams(newSearchParams);
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (keyword.trim() === '') {
+      return handleModalOpen(MODAL_MESSAGE_CUSTOMER_SERVICE.noKeyword);
+    } else {
+      onGetKeyword(keyword);
+      handleKeyword(keyword);
+      return;
+    }
+  };
+
+  const handleChangeKeyword = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setKeyword(value);
+  };
+
+  const handleClickSearchDefault = () => {
+    setKeyword('');
+    onGetKeyword('');
+    handleKeyword('');
+  };
+
+  return (
+    <S.AdminSearchBarContainer onSubmit={handleSubmit}>
+      <S.AdminSearchBarWrapper>
+        <S.AdminSearchBarInput
+          placeholder={MODAL_MESSAGE_CUSTOMER_SERVICE.noKeyword}
+          value={keyword ? keyword : value}
+          onChange={handleChangeKeyword}
+        />
+        {value && (
+          <S.AdminSearchBarBackIcon
+            type='button'
+            onClick={handleClickSearchDefault}
+          >
+            <XMarkIcon />
+          </S.AdminSearchBarBackIcon>
+        )}
+      </S.AdminSearchBarWrapper>
+      <S.AdminSearchBarButton>검색</S.AdminSearchBarButton>
+      <Modal isOpen={isOpen} onClose={handleModalClose}>
+        {message}
+      </Modal>
+    </S.AdminSearchBarContainer>
+  );
+}

--- a/src/components/common/admin/searchBar/SearchBar.tsx
+++ b/src/components/common/admin/searchBar/SearchBar.tsx
@@ -9,11 +9,16 @@ import { ADMIN_ROUTE } from '../../../../constants/routes';
 
 interface SearchBarProps {
   onGetKeyword: (value: string) => void;
+  value: string;
   isNotice?: boolean;
 }
 
-export default function SearchBar({ onGetKeyword, isNotice }: SearchBarProps) {
-  const [keyword, setKeyword] = useState<string>('');
+export default function SearchBar({
+  onGetKeyword,
+  value,
+  isNotice,
+}: SearchBarProps) {
+  const [keyword, setKeyword] = useState<string>(value);
   const { isOpen, message, handleModalOpen, handleModalClose } = useModal();
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -40,8 +45,7 @@ export default function SearchBar({ onGetKeyword, isNotice }: SearchBarProps) {
   };
 
   const handleChangeKeyword = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    setKeyword(value);
+    setKeyword(e.target.value);
   };
 
   const handleClickSearchDefault = () => {

--- a/src/components/common/admin/searchBar/SearchBar.tsx
+++ b/src/components/common/admin/searchBar/SearchBar.tsx
@@ -9,10 +9,9 @@ import { ADMIN_ROUTE } from '../../../../constants/routes';
 
 interface SearchBarProps {
   onGetKeyword: (value: string) => void;
-  value: string;
 }
 
-export default function SearchBar({ onGetKeyword, value }: SearchBarProps) {
+export default function SearchBar({ onGetKeyword }: SearchBarProps) {
   const [keyword, setKeyword] = useState<string>('');
   const { isOpen, message, handleModalOpen, handleModalClose } = useModal();
   const [searchParams, setSearchParams] = useSearchParams();

--- a/src/components/common/admin/searchBar/SearchBar.tsx
+++ b/src/components/common/admin/searchBar/SearchBar.tsx
@@ -9,9 +9,10 @@ import { ADMIN_ROUTE } from '../../../../constants/routes';
 
 interface SearchBarProps {
   onGetKeyword: (value: string) => void;
+  isNotice?: boolean;
 }
 
-export default function SearchBar({ onGetKeyword }: SearchBarProps) {
+export default function SearchBar({ onGetKeyword, isNotice }: SearchBarProps) {
   const [keyword, setKeyword] = useState<string>('');
   const { isOpen, message, handleModalOpen, handleModalClose } = useModal();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -70,9 +71,11 @@ export default function SearchBar({ onGetKeyword }: SearchBarProps) {
         </S.AdminSearchBarInputWrapper>
         <S.AdminSearchBarButton>검색</S.AdminSearchBarButton>
       </S.AdminSearchBarWrapper>
-      <S.WriteLink to={ADMIN_ROUTE.write} state={{ form: location.pathname }}>
-        작성하기
-      </S.WriteLink>
+      {isNotice && (
+        <S.WriteLink to={ADMIN_ROUTE.write} state={{ form: location.pathname }}>
+          작성하기
+        </S.WriteLink>
+      )}
       <Modal isOpen={isOpen} onClose={handleModalClose}>
         {message}
       </Modal>

--- a/src/constants/admin/adminModal.ts
+++ b/src/constants/admin/adminModal.ts
@@ -4,4 +4,5 @@ export const ADMIN_MODAL_MESSAGE = {
   writeDeleteSuccess: '삭제되었습니다.',
   writeDeleteFail: '삭제가 실패하였습니다.',
   writeError: '알수없는 에러가 발생했습니다.',
+  NO_RESULT: '결과가 존재하지 않습니다.',
 };

--- a/src/hooks/admin/useGetAllUsers.ts
+++ b/src/hooks/admin/useGetAllUsers.ts
@@ -1,15 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { UserData } from '../queries/user/keys';
 import { getAllUsers } from '../../api/auth.api';
+import { SearchType } from '../../models/search';
 
-export const useGetAllUsers = () => {
+export const useGetAllUsers = (searchUnit: SearchType) => {
   const {
     data: allUserData,
     isLoading,
     isFetching,
   } = useQuery({
-    queryKey: [UserData.allUser],
-    queryFn: () => getAllUsers(),
+    queryKey: [UserData.allUser, searchUnit.keyword, searchUnit.page],
+    queryFn: () => getAllUsers(searchUnit),
   });
 
   return { allUserData, isLoading, isFetching };

--- a/src/hooks/admin/useGetAllUsers.ts
+++ b/src/hooks/admin/useGetAllUsers.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { UserData } from '../queries/user/keys';
 import { getAllUsers } from '../../api/auth.api';
-import { SearchType } from '../../models/search';
+import type { SearchType } from '../../models/search';
 
 export const useGetAllUsers = (searchUnit: SearchType) => {
   const {

--- a/src/hooks/admin/useGetAllUsersPreview.ts
+++ b/src/hooks/admin/useGetAllUsersPreview.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { UserData } from '../queries/user/keys';
+import { getAllUsersPreview } from '../../api/auth.api';
+
+export const useGetAllUsersPreview = () => {
+  const {
+    data: allUserData,
+    isLoading,
+    isFetching,
+  } = useQuery({
+    queryKey: [UserData.allUserPreview],
+    queryFn: () => getAllUsersPreview(),
+    select: (allUsers) => allUsers.slice(0, 5),
+  });
+
+  return { allUserData, isLoading, isFetching };
+};

--- a/src/hooks/admin/useSearchBar.ts
+++ b/src/hooks/admin/useSearchBar.ts
@@ -16,6 +16,9 @@ const useSearchBar = () => {
     if (searchKeyword) {
       setSearchUnit((prev) => ({ ...prev, keyword: searchKeyword }));
       setValue((prev) => (searchKeyword ? searchKeyword : prev));
+    } else {
+      setSearchUnit((prev) => ({ ...prev, keyword: '' }));
+      setValue('');
     }
   }, [searchParams]);
 

--- a/src/hooks/admin/useSearchBar.ts
+++ b/src/hooks/admin/useSearchBar.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { SearchType } from '../../models/search';
+
+const useSearchBar = () => {
+  const [searchUnit, setSearchUnit] = useState<SearchType>({
+    keyword: '',
+    page: 1,
+  });
+  const [value, setValue] = useState<string>('');
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const searchKeyword = searchParams.get('keyword');
+
+    if (searchKeyword) {
+      setSearchUnit((prev) => ({ ...prev, keyword: searchKeyword }));
+      setValue((prev) => (searchKeyword ? searchKeyword : prev));
+    }
+  }, [searchParams]);
+
+  const handleGetKeyword = (keyword: string) => {
+    setSearchUnit((prev) => ({ ...prev, keyword }));
+    setValue(keyword);
+  };
+
+  const handleChangePagination = (page: number) => {
+    setSearchUnit((prev) => ({ ...prev, page }));
+  };
+
+  return { searchUnit, value, handleGetKeyword, handleChangePagination };
+};
+
+export default useSearchBar;

--- a/src/hooks/admin/useSearchBar.ts
+++ b/src/hooks/admin/useSearchBar.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { SearchType } from '../../models/search';
+import type { SearchType } from '../../models/search';
 
 const useSearchBar = () => {
   const [searchUnit, setSearchUnit] = useState<SearchType>({
@@ -20,7 +20,7 @@ const useSearchBar = () => {
   }, [searchParams]);
 
   const handleGetKeyword = (keyword: string) => {
-    setSearchUnit((prev) => ({ ...prev, keyword }));
+    setSearchUnit((prev) => ({ ...prev, keyword, page: 1 }));
     setValue(keyword);
   };
 

--- a/src/hooks/queries/user/keys.ts
+++ b/src/hooks/queries/user/keys.ts
@@ -62,4 +62,5 @@ export const ReportData = {
 
 export const UserData = {
   allUser: ['AllUser'],
+  allUserPreview: ['AllUserPreview'],
 };

--- a/src/mock/browser.ts
+++ b/src/mock/browser.ts
@@ -18,6 +18,7 @@ import {
 } from './mypage';
 import {
   userAll,
+  userAllPreview,
   userPageAppliedProjectList,
   userPageProfile,
 } from './userpage';
@@ -57,6 +58,7 @@ export const handlers = [
   createProject,
   reportsAll,
   userAll,
+  userAllPreview,
 ];
 
 export const worker = setupWorker(...handlers);

--- a/src/mock/mockAllUser.json
+++ b/src/mock/mockAllUser.json
@@ -1,0 +1,686 @@
+{
+  "success": true,
+  "message": "지원서 조회 성공",
+  "data": [
+    {
+      "id": 1,
+      "email": "user1@example.com",
+      "user": {
+        "id": 101,
+        "nickname": "alpha",
+        "img": "https://example.com/avatars/alpha.png"
+      },
+      "userState": "접속 중",
+      "createdAt": "2023-12-01",
+      "skill": [
+        {
+          "id": 11,
+          "name": "JavaScript",
+          "img": "https://example.com/skills/javascript.png",
+          "createdAt": "2023-01-10"
+        },
+        {
+          "id": 12,
+          "name": "React",
+          "img": "https://example.com/skills/react.png",
+          "createdAt": "2023-02-15"
+        }
+      ],
+      "position": [
+        {
+          "id": 21,
+          "name": "Frontend",
+          "createdAt": "2023-03-05"
+        },
+        {
+          "id": 21,
+          "name": "Frontend",
+          "createdAt": "2023-03-05"
+        },
+        {
+          "id": 21,
+          "name": "Frontend",
+          "createdAt": "2023-03-05"
+        },
+        {
+          "id": 21,
+          "name": "Frontend",
+          "createdAt": "2023-03-05"
+        },
+        {
+          "id": 21,
+          "name": "Frontend",
+          "createdAt": "2023-03-05"
+        }
+      ],
+      "reportedCount": 0
+    },
+    {
+      "id": 2,
+      "email": "user2@example.com",
+      "user": {
+        "id": 102,
+        "nickname": "bravo",
+        "img": "https://example.com/avatars/bravo.png"
+      },
+      "userState": "오프라인",
+      "createdAt": "2024-01-15",
+      "skill": [
+        {
+          "id": 13,
+          "name": "TypeScript",
+          "img": "https://example.com/skills/typescript.png",
+          "createdAt": "2023-04-12"
+        },
+        {
+          "id": 14,
+          "name": "HTML",
+          "img": "https://example.com/skills/html.png",
+          "createdAt": "2023-05-01"
+        }
+      ],
+      "position": [
+        {
+          "id": 22,
+          "name": "Fullstack",
+          "createdAt": "2023-06-20"
+        }
+      ],
+      "reportedCount": 1
+    },
+    {
+      "id": 3,
+      "email": "user3@example.com",
+      "user": {
+        "id": 103,
+        "nickname": "charlie",
+        "img": "https://example.com/avatars/charlie.png"
+      },
+      "userState": "정지",
+      "createdAt": "2022-11-20",
+      "skill": [
+        {
+          "id": 15,
+          "name": "CSS",
+          "img": "https://example.com/skills/css.png",
+          "createdAt": "2023-03-22"
+        },
+        {
+          "id": 16,
+          "name": "Node.js",
+          "img": "https://example.com/skills/nodejs.png",
+          "createdAt": "2023-04-18"
+        }
+      ],
+      "position": [
+        {
+          "id": 23,
+          "name": "Backend",
+          "createdAt": "2023-05-30"
+        }
+      ],
+      "reportedCount": 3
+    },
+    {
+      "id": 4,
+      "email": "user4@example.com",
+      "user": {
+        "id": 104,
+        "nickname": "delta",
+        "img": "https://example.com/avatars/delta.png"
+      },
+      "userState": "접속 중",
+      "createdAt": "2024-03-03",
+      "skill": [
+        {
+          "id": 17,
+          "name": "Python",
+          "img": "https://example.com/skills/python.png",
+          "createdAt": "2023-06-10"
+        },
+        {
+          "id": 18,
+          "name": "Docker",
+          "img": "https://example.com/skills/docker.png",
+          "createdAt": "2023-07-25"
+        }
+      ],
+      "position": [
+        {
+          "id": 24,
+          "name": "DevOps",
+          "createdAt": "2023-08-05"
+        }
+      ],
+      "reportedCount": 0
+    },
+    {
+      "id": 5,
+      "email": "user5@example.com",
+      "user": {
+        "id": 105,
+        "nickname": "echo",
+        "img": "https://example.com/avatars/echo.png"
+      },
+      "userState": "오프라인",
+      "createdAt": "2024-02-10",
+      "skill": [
+        {
+          "id": 19,
+          "name": "AWS",
+          "img": "https://example.com/skills/aws.png",
+          "createdAt": "2023-09-02"
+        },
+        {
+          "id": 20,
+          "name": "HTML",
+          "img": "https://example.com/skills/html.png",
+          "createdAt": "2023-05-01"
+        }
+      ],
+      "position": [
+        {
+          "id": 25,
+          "name": "Fullstack",
+          "createdAt": "2023-10-12"
+        }
+      ],
+      "reportedCount": 2
+    },
+    {
+      "id": 6,
+      "email": "user6@example.com",
+      "user": {
+        "id": 106,
+        "nickname": "foxtrot",
+        "img": "https://example.com/avatars/foxtrot.png"
+      },
+      "userState": "접속 중",
+      "createdAt": "2023-08-15",
+      "skill": [
+        {
+          "id": 21,
+          "name": "JavaScript",
+          "img": "https://example.com/skills/javascript.png",
+          "createdAt": "2023-01-10"
+        },
+        {
+          "id": 22,
+          "name": "React",
+          "img": "https://example.com/skills/react.png",
+          "createdAt": "2023-02-15"
+        }
+      ],
+      "position": [
+        {
+          "id": 26,
+          "name": "Frontend",
+          "createdAt": "2023-03-05"
+        }
+      ],
+      "reportedCount": 0
+    },
+    {
+      "id": 7,
+      "email": "user7@example.com",
+      "user": {
+        "id": 107,
+        "nickname": "golf",
+        "img": "https://example.com/avatars/golf.png"
+      },
+      "userState": "오프라인",
+      "createdAt": "2024-05-01",
+      "skill": [
+        {
+          "id": 23,
+          "name": "TypeScript",
+          "img": "https://example.com/skills/typescript.png",
+          "createdAt": "2023-04-12"
+        },
+        {
+          "id": 24,
+          "name": "CSS",
+          "img": "https://example.com/skills/css.png",
+          "createdAt": "2023-03-22"
+        }
+      ],
+      "position": [
+        {
+          "id": 27,
+          "name": "Frontend",
+          "createdAt": "2023-03-05"
+        }
+      ],
+      "reportedCount": 4
+    },
+    {
+      "id": 8,
+      "email": "user8@example.com",
+      "user": {
+        "id": 108,
+        "nickname": "hotel",
+        "img": "https://example.com/avatars/hotel.png"
+      },
+      "userState": "정지",
+      "createdAt": "2023-09-10",
+      "skill": [
+        {
+          "id": 25,
+          "name": "Node.js",
+          "img": "https://example.com/skills/nodejs.png",
+          "createdAt": "2023-04-18"
+        },
+        {
+          "id": 26,
+          "name": "Docker",
+          "img": "https://example.com/skills/docker.png",
+          "createdAt": "2023-07-25"
+        }
+      ],
+      "position": [
+        {
+          "id": 28,
+          "name": "Backend",
+          "createdAt": "2023-05-30"
+        }
+      ],
+      "reportedCount": 5
+    },
+    {
+      "id": 9,
+      "email": "user9@example.com",
+      "user": {
+        "id": 109,
+        "nickname": "india",
+        "img": "https://example.com/avatars/india.png"
+      },
+      "userState": "접속 중",
+      "createdAt": "2024-04-20",
+      "skill": [
+        {
+          "id": 27,
+          "name": "Python",
+          "img": "https://example.com/skills/python.png",
+          "createdAt": "2023-06-10"
+        },
+        {
+          "id": 28,
+          "name": "AWS",
+          "img": "https://example.com/skills/aws.png",
+          "createdAt": "2023-09-02"
+        }
+      ],
+      "position": [
+        {
+          "id": 29,
+          "name": "DevOps",
+          "createdAt": "2023-08-05"
+        }
+      ],
+      "reportedCount": 0
+    },
+    {
+      "id": 10,
+      "email": "user10@example.com",
+      "user": {
+        "id": 110,
+        "nickname": "juliet",
+        "img": "https://example.com/avatars/juliet.png"
+      },
+      "userState": "오프라인",
+      "createdAt": "2022-12-25",
+      "skill": [
+        {
+          "id": 29,
+          "name": "HTML",
+          "img": "https://example.com/skills/html.png",
+          "createdAt": "2023-05-01"
+        },
+        {
+          "id": 30,
+          "name": "CSS",
+          "img": "https://example.com/skills/css.png",
+          "createdAt": "2023-03-22"
+        }
+      ],
+      "position": [
+        {
+          "id": 30,
+          "name": "Frontend",
+          "createdAt": "2023-03-05"
+        }
+      ],
+      "reportedCount": 2
+    },
+    {
+      "id": 11,
+      "email": "user11@example.com",
+      "user": {
+        "id": 111,
+        "nickname": "kilo",
+        "img": "https://example.com/avatars/kilo.png"
+      },
+      "userState": "접속 중",
+      "createdAt": "2024-06-02",
+      "skill": [
+        {
+          "id": 31,
+          "name": "JavaScript",
+          "img": "https://example.com/skills/javascript.png",
+          "createdAt": "2023-01-10"
+        },
+        {
+          "id": 32,
+          "name": "React",
+          "img": "https://example.com/skills/react.png",
+          "createdAt": "2023-02-15"
+        }
+      ],
+      "position": [
+        {
+          "id": 31,
+          "name": "Fullstack",
+          "createdAt": "2023-06-20"
+        }
+      ],
+      "reportedCount": 1
+    },
+    {
+      "id": 12,
+      "email": "user12@example.com",
+      "user": {
+        "id": 112,
+        "nickname": "lima",
+        "img": "https://example.com/avatars/lima.png"
+      },
+      "userState": "오프라인",
+      "createdAt": "2023-07-18",
+      "skill": [
+        {
+          "id": 33,
+          "name": "TypeScript",
+          "img": "https://example.com/skills/typescript.png",
+          "createdAt": "2023-04-12"
+        },
+        {
+          "id": 34,
+          "name": "Node.js",
+          "img": "https://example.com/skills/nodejs.png",
+          "createdAt": "2023-04-18"
+        }
+      ],
+      "position": [
+        {
+          "id": 32,
+          "name": "Backend",
+          "createdAt": "2023-05-30"
+        }
+      ],
+      "reportedCount": 0
+    },
+    {
+      "id": 13,
+      "email": "user13@example.com",
+      "user": {
+        "id": 113,
+        "nickname": "mike",
+        "img": "https://example.com/avatars/mike.png"
+      },
+      "userState": "정지",
+      "createdAt": "2024-02-28",
+      "skill": [
+        {
+          "id": 35,
+          "name": "Docker",
+          "img": "https://example.com/skills/docker.png",
+          "createdAt": "2023-07-25"
+        },
+        {
+          "id": 36,
+          "name": "AWS",
+          "img": "https://example.com/skills/aws.png",
+          "createdAt": "2023-09-02"
+        }
+      ],
+      "position": [
+        {
+          "id": 33,
+          "name": "DevOps",
+          "createdAt": "2023-08-05"
+        }
+      ],
+      "reportedCount": 4
+    },
+    {
+      "id": 14,
+      "email": "user14@example.com",
+      "user": {
+        "id": 114,
+        "nickname": "november",
+        "img": "https://example.com/avatars/november.png"
+      },
+      "userState": "접속 중",
+      "createdAt": "2023-10-05",
+      "skill": [
+        {
+          "id": 37,
+          "name": "HTML",
+          "img": "https://example.com/skills/html.png",
+          "createdAt": "2023-05-01"
+        },
+        {
+          "id": 38,
+          "name": "CSS",
+          "img": "https://example.com/skills/css.png",
+          "createdAt": "2023-03-22"
+        }
+      ],
+      "position": [
+        {
+          "id": 34,
+          "name": "Frontend",
+          "createdAt": "2023-03-05"
+        }
+      ],
+      "reportedCount": 1
+    },
+    {
+      "id": 15,
+      "email": "user15@example.com",
+      "user": {
+        "id": 115,
+        "nickname": "oscar",
+        "img": "https://example.com/avatars/oscar.png"
+      },
+      "userState": "오프라인",
+      "createdAt": "2024-03-22",
+      "skill": [
+        {
+          "id": 39,
+          "name": "JavaScript",
+          "img": "https://example.com/skills/javascript.png",
+          "createdAt": "2023-01-10"
+        },
+        {
+          "id": 40,
+          "name": "React",
+          "img": "https://example.com/skills/react.png",
+          "createdAt": "2023-02-15"
+        }
+      ],
+      "position": [
+        {
+          "id": 35,
+          "name": "Fullstack",
+          "createdAt": "2023-06-20"
+        }
+      ],
+      "reportedCount": 2
+    },
+    {
+      "id": 16,
+      "email": "user16@example.com",
+      "user": {
+        "id": 116,
+        "nickname": "papa",
+        "img": "https://example.com/avatars/papa.png"
+      },
+      "userState": "접속 중",
+      "createdAt": "2023-11-11",
+      "skill": [
+        {
+          "id": 41,
+          "name": "TypeScript",
+          "img": "https://example.com/skills/typescript.png",
+          "createdAt": "2023-04-12"
+        },
+        {
+          "id": 42,
+          "name": "Node.js",
+          "img": "https://example.com/skills/nodejs.png",
+          "createdAt": "2023-04-18"
+        }
+      ],
+      "position": [
+        {
+          "id": 36,
+          "name": "Backend",
+          "createdAt": "2023-05-30"
+        }
+      ],
+      "reportedCount": 0
+    },
+    {
+      "id": 17,
+      "email": "user17@example.com",
+      "user": {
+        "id": 117,
+        "nickname": "quebec",
+        "img": "https://example.com/avatars/quebec.png"
+      },
+      "userState": "오프라인",
+      "createdAt": "2023-08-30",
+      "skill": [
+        {
+          "id": 43,
+          "name": "Docker",
+          "img": "https://example.com/skills/docker.png",
+          "createdAt": "2023-07-25"
+        },
+        {
+          "id": 44,
+          "name": "AWS",
+          "img": "https://example.com/skills/aws.png",
+          "createdAt": "2023-09-02"
+        }
+      ],
+      "position": [
+        {
+          "id": 37,
+          "name": "DevOps",
+          "createdAt": "2023-08-05"
+        }
+      ],
+      "reportedCount": 3
+    },
+    {
+      "id": 18,
+      "email": "user18@example.com",
+      "user": {
+        "id": 118,
+        "nickname": "romeo",
+        "img": "https://example.com/avatars/romeo.png"
+      },
+      "userState": "정지",
+      "createdAt": "2022-10-10",
+      "skill": [
+        {
+          "id": 45,
+          "name": "JavaScript",
+          "img": "https://example.com/skills/javascript.png",
+          "createdAt": "2023-01-10"
+        },
+        {
+          "id": 46,
+          "name": "React",
+          "img": "https://example.com/skills/react.png",
+          "createdAt": "2023-02-15"
+        }
+      ],
+      "position": [
+        {
+          "id": 38,
+          "name": "Frontend",
+          "createdAt": "2023-03-05"
+        }
+      ],
+      "reportedCount": 5
+    },
+    {
+      "id": 19,
+      "email": "user19@example.com",
+      "user": {
+        "id": 119,
+        "nickname": "sierra",
+        "img": "https://example.com/avatars/sierra.png"
+      },
+      "userState": "접속 중",
+      "createdAt": "2023-06-14",
+      "skill": [
+        {
+          "id": 47,
+          "name": "Python",
+          "img": "https://example.com/skills/python.png",
+          "createdAt": "2023-06-10"
+        },
+        {
+          "id": 48,
+          "name": "AWS",
+          "img": "https://example.com/skills/aws.png",
+          "createdAt": "2023-09-02"
+        }
+      ],
+      "position": [
+        {
+          "id": 39,
+          "name": "DevOps",
+          "createdAt": "2023-08-05"
+        }
+      ],
+      "reportedCount": 0
+    },
+    {
+      "id": 20,
+      "email": "user20@example.com",
+      "user": {
+        "id": 120,
+        "nickname": "tango",
+        "img": "https://example.com/avatars/tango.png"
+      },
+      "userState": "오프라인",
+      "createdAt": "2024-05-30",
+      "skill": [
+        {
+          "id": 49,
+          "name": "HTML",
+          "img": "https://example.com/skills/html.png",
+          "createdAt": "2023-05-01"
+        },
+        {
+          "id": 50,
+          "name": "CSS",
+          "img": "https://example.com/skills/css.png",
+          "createdAt": "2023-03-22"
+        }
+      ],
+      "position": [
+        {
+          "id": 40,
+          "name": "Frontend",
+          "createdAt": "2023-03-05"
+        }
+      ],
+      "reportedCount": 1
+    }
+  ]
+}

--- a/src/mock/mockAllUser.json
+++ b/src/mock/mockAllUser.json
@@ -1,686 +1,669 @@
 {
   "success": true,
-  "message": "지원서 조회 성공",
-  "data": [
-    {
-      "id": 1,
-      "email": "user1@example.com",
-      "user": {
-        "id": 101,
-        "nickname": "alpha",
-        "img": "https://example.com/avatars/alpha.png"
+  "message": "성공",
+  "data": {
+    "allUsers": [
+      {
+        "id": 1,
+        "email": "user1@example.com",
+        "user": {
+          "id": 101,
+          "nickname": "alpha",
+          "img": "https://example.com/avatars/alpha.png"
+        },
+        "userState": "접속 중",
+        "createdAt": "2023-12-01",
+        "skill": [
+          {
+            "id": 11,
+            "name": "JavaScript",
+            "img": "https://example.com/skills/javascript.png",
+            "createdAt": "2023-01-10"
+          },
+          {
+            "id": 12,
+            "name": "React",
+            "img": "https://example.com/skills/react.png",
+            "createdAt": "2023-02-15"
+          }
+        ],
+        "position": [
+          {
+            "id": 21,
+            "name": "Frontend",
+            "createdAt": "2023-03-05"
+          }
+        ],
+        "reportedCount": 0
       },
-      "userState": "접속 중",
-      "createdAt": "2023-12-01",
-      "skill": [
-        {
-          "id": 11,
-          "name": "JavaScript",
-          "img": "https://example.com/skills/javascript.png",
-          "createdAt": "2023-01-10"
+      {
+        "id": 2,
+        "email": "user2@example.com",
+        "user": {
+          "id": 102,
+          "nickname": "bravo",
+          "img": "https://example.com/avatars/bravo.png"
         },
-        {
-          "id": 12,
-          "name": "React",
-          "img": "https://example.com/skills/react.png",
-          "createdAt": "2023-02-15"
-        }
-      ],
-      "position": [
-        {
-          "id": 21,
-          "name": "Frontend",
-          "createdAt": "2023-03-05"
-        },
-        {
-          "id": 21,
-          "name": "Frontend",
-          "createdAt": "2023-03-05"
-        },
-        {
-          "id": 21,
-          "name": "Frontend",
-          "createdAt": "2023-03-05"
-        },
-        {
-          "id": 21,
-          "name": "Frontend",
-          "createdAt": "2023-03-05"
-        },
-        {
-          "id": 21,
-          "name": "Frontend",
-          "createdAt": "2023-03-05"
-        }
-      ],
-      "reportedCount": 0
-    },
-    {
-      "id": 2,
-      "email": "user2@example.com",
-      "user": {
-        "id": 102,
-        "nickname": "bravo",
-        "img": "https://example.com/avatars/bravo.png"
+        "userState": "오프라인",
+        "createdAt": "2024-01-15",
+        "skill": [
+          {
+            "id": 13,
+            "name": "TypeScript",
+            "img": "https://example.com/skills/typescript.png",
+            "createdAt": "2023-04-12"
+          },
+          {
+            "id": 14,
+            "name": "HTML",
+            "img": "https://example.com/skills/html.png",
+            "createdAt": "2023-05-01"
+          }
+        ],
+        "position": [
+          {
+            "id": 22,
+            "name": "Fullstack",
+            "createdAt": "2023-06-20"
+          }
+        ],
+        "reportedCount": 1
       },
-      "userState": "오프라인",
-      "createdAt": "2024-01-15",
-      "skill": [
-        {
-          "id": 13,
-          "name": "TypeScript",
-          "img": "https://example.com/skills/typescript.png",
-          "createdAt": "2023-04-12"
+      {
+        "id": 3,
+        "email": "user3@example.com",
+        "user": {
+          "id": 103,
+          "nickname": "charlie",
+          "img": "https://example.com/avatars/charlie.png"
         },
-        {
-          "id": 14,
-          "name": "HTML",
-          "img": "https://example.com/skills/html.png",
-          "createdAt": "2023-05-01"
-        }
-      ],
-      "position": [
-        {
-          "id": 22,
-          "name": "Fullstack",
-          "createdAt": "2023-06-20"
-        }
-      ],
-      "reportedCount": 1
-    },
-    {
-      "id": 3,
-      "email": "user3@example.com",
-      "user": {
-        "id": 103,
-        "nickname": "charlie",
-        "img": "https://example.com/avatars/charlie.png"
+        "userState": "정지",
+        "createdAt": "2022-11-20",
+        "skill": [
+          {
+            "id": 15,
+            "name": "CSS",
+            "img": "https://example.com/skills/css.png",
+            "createdAt": "2023-03-22"
+          },
+          {
+            "id": 16,
+            "name": "Node.js",
+            "img": "https://example.com/skills/nodejs.png",
+            "createdAt": "2023-04-18"
+          }
+        ],
+        "position": [
+          {
+            "id": 23,
+            "name": "Backend",
+            "createdAt": "2023-05-30"
+          }
+        ],
+        "reportedCount": 3
       },
-      "userState": "정지",
-      "createdAt": "2022-11-20",
-      "skill": [
-        {
-          "id": 15,
-          "name": "CSS",
-          "img": "https://example.com/skills/css.png",
-          "createdAt": "2023-03-22"
+      {
+        "id": 4,
+        "email": "user4@example.com",
+        "user": {
+          "id": 104,
+          "nickname": "delta",
+          "img": "https://example.com/avatars/delta.png"
         },
-        {
-          "id": 16,
-          "name": "Node.js",
-          "img": "https://example.com/skills/nodejs.png",
-          "createdAt": "2023-04-18"
-        }
-      ],
-      "position": [
-        {
-          "id": 23,
-          "name": "Backend",
-          "createdAt": "2023-05-30"
-        }
-      ],
-      "reportedCount": 3
-    },
-    {
-      "id": 4,
-      "email": "user4@example.com",
-      "user": {
-        "id": 104,
-        "nickname": "delta",
-        "img": "https://example.com/avatars/delta.png"
+        "userState": "접속 중",
+        "createdAt": "2024-03-03",
+        "skill": [
+          {
+            "id": 17,
+            "name": "Python",
+            "img": "https://example.com/skills/python.png",
+            "createdAt": "2023-06-10"
+          },
+          {
+            "id": 18,
+            "name": "Docker",
+            "img": "https://example.com/skills/docker.png",
+            "createdAt": "2023-07-25"
+          }
+        ],
+        "position": [
+          {
+            "id": 24,
+            "name": "DevOps",
+            "createdAt": "2023-08-05"
+          }
+        ],
+        "reportedCount": 0
       },
-      "userState": "접속 중",
-      "createdAt": "2024-03-03",
-      "skill": [
-        {
-          "id": 17,
-          "name": "Python",
-          "img": "https://example.com/skills/python.png",
-          "createdAt": "2023-06-10"
+      {
+        "id": 5,
+        "email": "user5@example.com",
+        "user": {
+          "id": 105,
+          "nickname": "echo",
+          "img": "https://example.com/avatars/echo.png"
         },
-        {
-          "id": 18,
-          "name": "Docker",
-          "img": "https://example.com/skills/docker.png",
-          "createdAt": "2023-07-25"
-        }
-      ],
-      "position": [
-        {
-          "id": 24,
-          "name": "DevOps",
-          "createdAt": "2023-08-05"
-        }
-      ],
-      "reportedCount": 0
-    },
-    {
-      "id": 5,
-      "email": "user5@example.com",
-      "user": {
-        "id": 105,
-        "nickname": "echo",
-        "img": "https://example.com/avatars/echo.png"
+        "userState": "오프라인",
+        "createdAt": "2024-02-10",
+        "skill": [
+          {
+            "id": 19,
+            "name": "AWS",
+            "img": "https://example.com/skills/aws.png",
+            "createdAt": "2023-09-02"
+          },
+          {
+            "id": 20,
+            "name": "HTML",
+            "img": "https://example.com/skills/html.png",
+            "createdAt": "2023-05-01"
+          }
+        ],
+        "position": [
+          {
+            "id": 25,
+            "name": "Fullstack",
+            "createdAt": "2023-10-12"
+          }
+        ],
+        "reportedCount": 2
       },
-      "userState": "오프라인",
-      "createdAt": "2024-02-10",
-      "skill": [
-        {
-          "id": 19,
-          "name": "AWS",
-          "img": "https://example.com/skills/aws.png",
-          "createdAt": "2023-09-02"
+      {
+        "id": 6,
+        "email": "user6@example.com",
+        "user": {
+          "id": 106,
+          "nickname": "foxtrot",
+          "img": "https://example.com/avatars/foxtrot.png"
         },
-        {
-          "id": 20,
-          "name": "HTML",
-          "img": "https://example.com/skills/html.png",
-          "createdAt": "2023-05-01"
-        }
-      ],
-      "position": [
-        {
-          "id": 25,
-          "name": "Fullstack",
-          "createdAt": "2023-10-12"
-        }
-      ],
-      "reportedCount": 2
-    },
-    {
-      "id": 6,
-      "email": "user6@example.com",
-      "user": {
-        "id": 106,
-        "nickname": "foxtrot",
-        "img": "https://example.com/avatars/foxtrot.png"
+        "userState": "정지",
+        "createdAt": "2023-08-15T21:30:00Z",
+        "skill": [
+          {
+            "id": 21,
+            "name": "JavaScript",
+            "img": "https://example.com/skills/javascript.png",
+            "createdAt": "2023-01-10"
+          },
+          {
+            "id": 22,
+            "name": "React",
+            "img": "https://example.com/skills/react.png",
+            "createdAt": "2023-02-15"
+          }
+        ],
+        "position": [
+          {
+            "id": 26,
+            "name": "Frontend",
+            "createdAt": "2023-03-05"
+          }
+        ],
+        "reportedCount": 0
       },
-      "userState": "접속 중",
-      "createdAt": "2023-08-15",
-      "skill": [
-        {
-          "id": 21,
-          "name": "JavaScript",
-          "img": "https://example.com/skills/javascript.png",
-          "createdAt": "2023-01-10"
+      {
+        "id": 7,
+        "email": "user7@example.com",
+        "user": {
+          "id": 107,
+          "nickname": "golf",
+          "img": "https://example.com/avatars/golf.png"
         },
-        {
-          "id": 22,
-          "name": "React",
-          "img": "https://example.com/skills/react.png",
-          "createdAt": "2023-02-15"
-        }
-      ],
-      "position": [
-        {
-          "id": 26,
-          "name": "Frontend",
-          "createdAt": "2023-03-05"
-        }
-      ],
-      "reportedCount": 0
-    },
-    {
-      "id": 7,
-      "email": "user7@example.com",
-      "user": {
-        "id": 107,
-        "nickname": "golf",
-        "img": "https://example.com/avatars/golf.png"
+        "userState": "접속 중",
+        "createdAt": "2024-05-01",
+        "skill": [
+          {
+            "id": 23,
+            "name": "TypeScript",
+            "img": "https://example.com/skills/typescript.png",
+            "createdAt": "2023-04-12"
+          },
+          {
+            "id": 24,
+            "name": "CSS",
+            "img": "https://example.com/skills/css.png",
+            "createdAt": "2023-03-22"
+          }
+        ],
+        "position": [
+          {
+            "id": 27,
+            "name": "Frontend",
+            "createdAt": "2023-03-05"
+          }
+        ],
+        "reportedCount": 4
       },
-      "userState": "오프라인",
-      "createdAt": "2024-05-01",
-      "skill": [
-        {
-          "id": 23,
-          "name": "TypeScript",
-          "img": "https://example.com/skills/typescript.png",
-          "createdAt": "2023-04-12"
+      {
+        "id": 8,
+        "email": "user8@example.com",
+        "user": {
+          "id": 108,
+          "nickname": "hotel",
+          "img": "https://example.com/avatars/hotel.png"
         },
-        {
-          "id": 24,
-          "name": "CSS",
-          "img": "https://example.com/skills/css.png",
-          "createdAt": "2023-03-22"
-        }
-      ],
-      "position": [
-        {
-          "id": 27,
-          "name": "Frontend",
-          "createdAt": "2023-03-05"
-        }
-      ],
-      "reportedCount": 4
-    },
-    {
-      "id": 8,
-      "email": "user8@example.com",
-      "user": {
-        "id": 108,
-        "nickname": "hotel",
-        "img": "https://example.com/avatars/hotel.png"
+        "userState": "오프라인",
+        "createdAt": "2023-09-10",
+        "skill": [
+          {
+            "id": 25,
+            "name": "Node.js",
+            "img": "https://example.com/skills/nodejs.png",
+            "createdAt": "2023-04-18"
+          },
+          {
+            "id": 26,
+            "name": "Docker",
+            "img": "https://example.com/skills/docker.png",
+            "createdAt": "2023-07-25"
+          }
+        ],
+        "position": [
+          {
+            "id": 28,
+            "name": "Backend",
+            "createdAt": "2023-05-30"
+          }
+        ],
+        "reportedCount": 5
       },
-      "userState": "정지",
-      "createdAt": "2023-09-10",
-      "skill": [
-        {
-          "id": 25,
-          "name": "Node.js",
-          "img": "https://example.com/skills/nodejs.png",
-          "createdAt": "2023-04-18"
+      {
+        "id": 9,
+        "email": "user9@example.com",
+        "user": {
+          "id": 109,
+          "nickname": "india",
+          "img": "https://example.com/avatars/india.png"
         },
-        {
-          "id": 26,
-          "name": "Docker",
-          "img": "https://example.com/skills/docker.png",
-          "createdAt": "2023-07-25"
-        }
-      ],
-      "position": [
-        {
-          "id": 28,
-          "name": "Backend",
-          "createdAt": "2023-05-30"
-        }
-      ],
-      "reportedCount": 5
-    },
-    {
-      "id": 9,
-      "email": "user9@example.com",
-      "user": {
-        "id": 109,
-        "nickname": "india",
-        "img": "https://example.com/avatars/india.png"
+        "userState": "정지",
+        "createdAt": "2024-04-20",
+        "skill": [
+          {
+            "id": 27,
+            "name": "Python",
+            "img": "https://example.com/skills/python.png",
+            "createdAt": "2023-06-10"
+          },
+          {
+            "id": 28,
+            "name": "AWS",
+            "img": "https://example.com/skills/aws.png",
+            "createdAt": "2023-09-02"
+          }
+        ],
+        "position": [
+          {
+            "id": 29,
+            "name": "DevOps",
+            "createdAt": "2023-08-05"
+          }
+        ],
+        "reportedCount": 0
       },
-      "userState": "접속 중",
-      "createdAt": "2024-04-20",
-      "skill": [
-        {
-          "id": 27,
-          "name": "Python",
-          "img": "https://example.com/skills/python.png",
-          "createdAt": "2023-06-10"
+      {
+        "id": 10,
+        "email": "user10@example.com",
+        "user": {
+          "id": 110,
+          "nickname": "juliet",
+          "img": "https://example.com/avatars/juliet.png"
         },
-        {
-          "id": 28,
-          "name": "AWS",
-          "img": "https://example.com/skills/aws.png",
-          "createdAt": "2023-09-02"
-        }
-      ],
-      "position": [
-        {
-          "id": 29,
-          "name": "DevOps",
-          "createdAt": "2023-08-05"
-        }
-      ],
-      "reportedCount": 0
-    },
-    {
-      "id": 10,
-      "email": "user10@example.com",
-      "user": {
-        "id": 110,
-        "nickname": "juliet",
-        "img": "https://example.com/avatars/juliet.png"
+        "userState": "접속 중",
+        "createdAt": "2022-12-25",
+        "skill": [
+          {
+            "id": 29,
+            "name": "HTML",
+            "img": "https://example.com/skills/html.png",
+            "createdAt": "2023-05-01"
+          },
+          {
+            "id": 30,
+            "name": "CSS",
+            "img": "https://example.com/skills/css.png",
+            "createdAt": "2023-03-22"
+          }
+        ],
+        "position": [
+          {
+            "id": 30,
+            "name": "Frontend",
+            "createdAt": "2023-03-05"
+          }
+        ],
+        "reportedCount": 2
       },
-      "userState": "오프라인",
-      "createdAt": "2022-12-25",
-      "skill": [
-        {
-          "id": 29,
-          "name": "HTML",
-          "img": "https://example.com/skills/html.png",
-          "createdAt": "2023-05-01"
+      {
+        "id": 11,
+        "email": "user11@example.com",
+        "user": {
+          "id": 111,
+          "nickname": "kilo",
+          "img": "https://example.com/avatars/kilo.png"
         },
-        {
-          "id": 30,
-          "name": "CSS",
-          "img": "https://example.com/skills/css.png",
-          "createdAt": "2023-03-22"
-        }
-      ],
-      "position": [
-        {
-          "id": 30,
-          "name": "Frontend",
-          "createdAt": "2023-03-05"
-        }
-      ],
-      "reportedCount": 2
-    },
-    {
-      "id": 11,
-      "email": "user11@example.com",
-      "user": {
-        "id": 111,
-        "nickname": "kilo",
-        "img": "https://example.com/avatars/kilo.png"
+        "userState": "오프라인",
+        "createdAt": "2024-06-02",
+        "skill": [
+          {
+            "id": 31,
+            "name": "JavaScript",
+            "img": "https://example.com/skills/javascript.png",
+            "createdAt": "2023-01-10"
+          },
+          {
+            "id": 32,
+            "name": "React",
+            "img": "https://example.com/skills/react.png",
+            "createdAt": "2023-02-15"
+          }
+        ],
+        "position": [
+          {
+            "id": 31,
+            "name": "Fullstack",
+            "createdAt": "2023-06-20"
+          }
+        ],
+        "reportedCount": 1
       },
-      "userState": "접속 중",
-      "createdAt": "2024-06-02",
-      "skill": [
-        {
-          "id": 31,
-          "name": "JavaScript",
-          "img": "https://example.com/skills/javascript.png",
-          "createdAt": "2023-01-10"
+      {
+        "id": 12,
+        "email": "user12@example.com",
+        "user": {
+          "id": 112,
+          "nickname": "lima",
+          "img": "https://example.com/avatars/lima.png"
         },
-        {
-          "id": 32,
-          "name": "React",
-          "img": "https://example.com/skills/react.png",
-          "createdAt": "2023-02-15"
-        }
-      ],
-      "position": [
-        {
-          "id": 31,
-          "name": "Fullstack",
-          "createdAt": "2023-06-20"
-        }
-      ],
-      "reportedCount": 1
-    },
-    {
-      "id": 12,
-      "email": "user12@example.com",
-      "user": {
-        "id": 112,
-        "nickname": "lima",
-        "img": "https://example.com/avatars/lima.png"
+        "userState": "정지",
+        "createdAt": "2023-07-18",
+        "skill": [
+          {
+            "id": 33,
+            "name": "TypeScript",
+            "img": "https://example.com/skills/typescript.png",
+            "createdAt": "2023-04-12"
+          },
+          {
+            "id": 34,
+            "name": "Node.js",
+            "img": "https://example.com/skills/nodejs.png",
+            "createdAt": "2023-04-18"
+          }
+        ],
+        "position": [
+          {
+            "id": 32,
+            "name": "Backend",
+            "createdAt": "2023-05-30"
+          }
+        ],
+        "reportedCount": 0
       },
-      "userState": "오프라인",
-      "createdAt": "2023-07-18",
-      "skill": [
-        {
-          "id": 33,
-          "name": "TypeScript",
-          "img": "https://example.com/skills/typescript.png",
-          "createdAt": "2023-04-12"
+      {
+        "id": 13,
+        "email": "user13@example.com",
+        "user": {
+          "id": 113,
+          "nickname": "mike",
+          "img": "https://example.com/avatars/mike.png"
         },
-        {
-          "id": 34,
-          "name": "Node.js",
-          "img": "https://example.com/skills/nodejs.png",
-          "createdAt": "2023-04-18"
-        }
-      ],
-      "position": [
-        {
-          "id": 32,
-          "name": "Backend",
-          "createdAt": "2023-05-30"
-        }
-      ],
-      "reportedCount": 0
-    },
-    {
-      "id": 13,
-      "email": "user13@example.com",
-      "user": {
-        "id": 113,
-        "nickname": "mike",
-        "img": "https://example.com/avatars/mike.png"
+        "userState": "접속 중",
+        "createdAt": "2024-02-28T20:15:00Z",
+        "skill": [
+          {
+            "id": 35,
+            "name": "Docker",
+            "img": "https://example.com/skills/docker.png",
+            "createdAt": "2023-07-25"
+          },
+          {
+            "id": 36,
+            "name": "AWS",
+            "img": "https://example.com/skills/aws.png",
+            "createdAt": "2023-09-02"
+          }
+        ],
+        "position": [
+          {
+            "id": 33,
+            "name": "DevOps",
+            "createdAt": "2023-08-05"
+          }
+        ],
+        "reportedCount": 4
       },
-      "userState": "정지",
-      "createdAt": "2024-02-28",
-      "skill": [
-        {
-          "id": 35,
-          "name": "Docker",
-          "img": "https://example.com/skills/docker.png",
-          "createdAt": "2023-07-25"
+      {
+        "id": 14,
+        "email": "user14@example.com",
+        "user": {
+          "id": 114,
+          "nickname": "november",
+          "img": "https://example.com/avatars/november.png"
         },
-        {
-          "id": 36,
-          "name": "AWS",
-          "img": "https://example.com/skills/aws.png",
-          "createdAt": "2023-09-02"
-        }
-      ],
-      "position": [
-        {
-          "id": 33,
-          "name": "DevOps",
-          "createdAt": "2023-08-05"
-        }
-      ],
-      "reportedCount": 4
-    },
-    {
-      "id": 14,
-      "email": "user14@example.com",
-      "user": {
-        "id": 114,
-        "nickname": "november",
-        "img": "https://example.com/avatars/november.png"
+        "userState": "오프라인",
+        "createdAt": "2023-10-05",
+        "skill": [
+          {
+            "id": 37,
+            "name": "HTML",
+            "img": "https://example.com/skills/html.png",
+            "createdAt": "2023-05-01"
+          },
+          {
+            "id": 38,
+            "name": "CSS",
+            "img": "https://example.com/skills/css.png",
+            "createdAt": "2023-03-22"
+          }
+        ],
+        "position": [
+          {
+            "id": 34,
+            "name": "Frontend",
+            "createdAt": "2023-03-05"
+          }
+        ],
+        "reportedCount": 1
       },
-      "userState": "접속 중",
-      "createdAt": "2023-10-05",
-      "skill": [
-        {
-          "id": 37,
-          "name": "HTML",
-          "img": "https://example.com/skills/html.png",
-          "createdAt": "2023-05-01"
+      {
+        "id": 15,
+        "email": "user15@example.com",
+        "user": {
+          "id": 115,
+          "nickname": "oscar",
+          "img": "https://example.com/avatars/oscar.png"
         },
-        {
-          "id": 38,
-          "name": "CSS",
-          "img": "https://example.com/skills/css.png",
-          "createdAt": "2023-03-22"
-        }
-      ],
-      "position": [
-        {
-          "id": 34,
-          "name": "Frontend",
-          "createdAt": "2023-03-05"
-        }
-      ],
-      "reportedCount": 1
-    },
-    {
-      "id": 15,
-      "email": "user15@example.com",
-      "user": {
-        "id": 115,
-        "nickname": "oscar",
-        "img": "https://example.com/avatars/oscar.png"
+        "userState": "정지",
+        "createdAt": "2024-03-22",
+        "skill": [
+          {
+            "id": 39,
+            "name": "JavaScript",
+            "img": "https://example.com/skills/javascript.png",
+            "createdAt": "2023-01-10"
+          },
+          {
+            "id": 40,
+            "name": "React",
+            "img": "https://example.com/skills/react.png",
+            "createdAt": "2023-02-15"
+          }
+        ],
+        "position": [
+          {
+            "id": 35,
+            "name": "Fullstack",
+            "createdAt": "2023-06-20"
+          }
+        ],
+        "reportedCount": 2
       },
-      "userState": "오프라인",
-      "createdAt": "2024-03-22",
-      "skill": [
-        {
-          "id": 39,
-          "name": "JavaScript",
-          "img": "https://example.com/skills/javascript.png",
-          "createdAt": "2023-01-10"
+      {
+        "id": 16,
+        "email": "user16@example.com",
+        "user": {
+          "id": 116,
+          "nickname": "papa",
+          "img": "https://example.com/avatars/papa.png"
         },
-        {
-          "id": 40,
-          "name": "React",
-          "img": "https://example.com/skills/react.png",
-          "createdAt": "2023-02-15"
-        }
-      ],
-      "position": [
-        {
-          "id": 35,
-          "name": "Fullstack",
-          "createdAt": "2023-06-20"
-        }
-      ],
-      "reportedCount": 2
-    },
-    {
-      "id": 16,
-      "email": "user16@example.com",
-      "user": {
-        "id": 116,
-        "nickname": "papa",
-        "img": "https://example.com/avatars/papa.png"
+        "userState": "접속 중",
+        "createdAt": "2023-11-11",
+        "skill": [
+          {
+            "id": 41,
+            "name": "TypeScript",
+            "img": "https://example.com/skills/typescript.png",
+            "createdAt": "2023-04-12"
+          },
+          {
+            "id": 42,
+            "name": "Node.js",
+            "img": "https://example.com/skills/nodejs.png",
+            "createdAt": "2023-04-18"
+          }
+        ],
+        "position": [
+          {
+            "id": 36,
+            "name": "Backend",
+            "createdAt": "2023-05-30"
+          }
+        ],
+        "reportedCount": 0
       },
-      "userState": "접속 중",
-      "createdAt": "2023-11-11",
-      "skill": [
-        {
-          "id": 41,
-          "name": "TypeScript",
-          "img": "https://example.com/skills/typescript.png",
-          "createdAt": "2023-04-12"
+      {
+        "id": 17,
+        "email": "user17@example.com",
+        "user": {
+          "id": 117,
+          "nickname": "quebec",
+          "img": "https://example.com/avatars/quebec.png"
         },
-        {
-          "id": 42,
-          "name": "Node.js",
-          "img": "https://example.com/skills/nodejs.png",
-          "createdAt": "2023-04-18"
-        }
-      ],
-      "position": [
-        {
-          "id": 36,
-          "name": "Backend",
-          "createdAt": "2023-05-30"
-        }
-      ],
-      "reportedCount": 0
-    },
-    {
-      "id": 17,
-      "email": "user17@example.com",
-      "user": {
-        "id": 117,
-        "nickname": "quebec",
-        "img": "https://example.com/avatars/quebec.png"
+        "userState": "오프라인",
+        "createdAt": "2023-08-30",
+        "skill": [
+          {
+            "id": 43,
+            "name": "Docker",
+            "img": "https://example.com/skills/docker.png",
+            "createdAt": "2023-07-25"
+          },
+          {
+            "id": 44,
+            "name": "AWS",
+            "img": "https://example.com/skills/aws.png",
+            "createdAt": "2023-09-02"
+          }
+        ],
+        "position": [
+          {
+            "id": 37,
+            "name": "DevOps",
+            "createdAt": "2023-08-05"
+          }
+        ],
+        "reportedCount": 3
       },
-      "userState": "오프라인",
-      "createdAt": "2023-08-30",
-      "skill": [
-        {
-          "id": 43,
-          "name": "Docker",
-          "img": "https://example.com/skills/docker.png",
-          "createdAt": "2023-07-25"
+      {
+        "id": 18,
+        "email": "user18@example.com",
+        "user": {
+          "id": 118,
+          "nickname": "romeo",
+          "img": "https://example.com/avatars/romeo.png"
         },
-        {
-          "id": 44,
-          "name": "AWS",
-          "img": "https://example.com/skills/aws.png",
-          "createdAt": "2023-09-02"
-        }
-      ],
-      "position": [
-        {
-          "id": 37,
-          "name": "DevOps",
-          "createdAt": "2023-08-05"
-        }
-      ],
-      "reportedCount": 3
-    },
-    {
-      "id": 18,
-      "email": "user18@example.com",
-      "user": {
-        "id": 118,
-        "nickname": "romeo",
-        "img": "https://example.com/avatars/romeo.png"
+        "userState": "정지",
+        "createdAt": "2022-10-10",
+        "skill": [
+          {
+            "id": 45,
+            "name": "JavaScript",
+            "img": "https://example.com/skills/javascript.png",
+            "createdAt": "2023-01-10"
+          },
+          {
+            "id": 46,
+            "name": "React",
+            "img": "https://example.com/skills/react.png",
+            "createdAt": "2023-02-15"
+          }
+        ],
+        "position": [
+          {
+            "id": 38,
+            "name": "Frontend",
+            "createdAt": "2023-03-05"
+          }
+        ],
+        "reportedCount": 5
       },
-      "userState": "정지",
-      "createdAt": "2022-10-10",
-      "skill": [
-        {
-          "id": 45,
-          "name": "JavaScript",
-          "img": "https://example.com/skills/javascript.png",
-          "createdAt": "2023-01-10"
+      {
+        "id": 19,
+        "email": "user19@example.com",
+        "user": {
+          "id": 119,
+          "nickname": "sierra",
+          "img": "https://example.com/avatars/sierra.png"
         },
-        {
-          "id": 46,
-          "name": "React",
-          "img": "https://example.com/skills/react.png",
-          "createdAt": "2023-02-15"
-        }
-      ],
-      "position": [
-        {
-          "id": 38,
-          "name": "Frontend",
-          "createdAt": "2023-03-05"
-        }
-      ],
-      "reportedCount": 5
-    },
-    {
-      "id": 19,
-      "email": "user19@example.com",
-      "user": {
-        "id": 119,
-        "nickname": "sierra",
-        "img": "https://example.com/avatars/sierra.png"
+        "userState": "접속 중",
+        "createdAt": "2023-06-14",
+        "skill": [
+          {
+            "id": 47,
+            "name": "Python",
+            "img": "https://example.com/skills/python.png",
+            "createdAt": "2023-06-10"
+          },
+          {
+            "id": 48,
+            "name": "AWS",
+            "img": "https://example.com/skills/aws.png",
+            "createdAt": "2023-09-02"
+          }
+        ],
+        "position": [
+          {
+            "id": 39,
+            "name": "DevOps",
+            "createdAt": "2023-08-05"
+          }
+        ],
+        "reportedCount": 0
       },
-      "userState": "접속 중",
-      "createdAt": "2023-06-14",
-      "skill": [
-        {
-          "id": 47,
-          "name": "Python",
-          "img": "https://example.com/skills/python.png",
-          "createdAt": "2023-06-10"
+      {
+        "id": 20,
+        "email": "user20@example.com",
+        "user": {
+          "id": 120,
+          "nickname": "tango",
+          "img": "https://example.com/avatars/tango.png"
         },
-        {
-          "id": 48,
-          "name": "AWS",
-          "img": "https://example.com/skills/aws.png",
-          "createdAt": "2023-09-02"
-        }
-      ],
-      "position": [
-        {
-          "id": 39,
-          "name": "DevOps",
-          "createdAt": "2023-08-05"
-        }
-      ],
-      "reportedCount": 0
-    },
-    {
-      "id": 20,
-      "email": "user20@example.com",
-      "user": {
-        "id": 120,
-        "nickname": "tango",
-        "img": "https://example.com/avatars/tango.png"
-      },
-      "userState": "오프라인",
-      "createdAt": "2024-05-30",
-      "skill": [
-        {
-          "id": 49,
-          "name": "HTML",
-          "img": "https://example.com/skills/html.png",
-          "createdAt": "2023-05-01"
-        },
-        {
-          "id": 50,
-          "name": "CSS",
-          "img": "https://example.com/skills/css.png",
-          "createdAt": "2023-03-22"
-        }
-      ],
-      "position": [
-        {
-          "id": 40,
-          "name": "Frontend",
-          "createdAt": "2023-03-05"
-        }
-      ],
-      "reportedCount": 1
-    }
-  ]
+        "userState": "오프라인",
+        "createdAt": "2024-05-30",
+        "skill": [
+          {
+            "id": 49,
+            "name": "HTML",
+            "img": "https://example.com/skills/html.png",
+            "createdAt": "2023-05-01"
+          },
+          {
+            "id": 50,
+            "name": "CSS",
+            "img": "https://example.com/skills/css.png",
+            "createdAt": "2023-03-22"
+          }
+        ],
+        "position": [
+          {
+            "id": 40,
+            "name": "Frontend",
+            "createdAt": "2023-03-05"
+          }
+        ],
+        "reportedCount": 1
+      }
+    ],
+    "totalPages": 2
+  }
 }

--- a/src/mock/mockAllUser.json
+++ b/src/mock/mockAllUser.json
@@ -177,7 +177,7 @@
           "img": "https://example.com/avatars/foxtrot.png"
         },
         "userState": "정지",
-        "createdAt": "2023-08-15T21:30:00Z",
+        "createdAt": "2023-08-15",
         "skill": [
           {
             "id": 21,
@@ -408,7 +408,7 @@
           "img": "https://example.com/avatars/mike.png"
         },
         "userState": "접속 중",
-        "createdAt": "2024-02-28T20:15:00Z",
+        "createdAt": "2024-02-28",
         "skill": [
           {
             "id": 35,

--- a/src/mock/userpage.ts
+++ b/src/mock/userpage.ts
@@ -21,6 +21,13 @@ export const userPageAppliedProjectList = http.get(
   }
 );
 
+export const userAllPreview = http.get(
+  `${import.meta.env.VITE_APP_API_BASE_URL}users/preview`,
+  () => {
+    return HttpResponse.json(mockUsers, { status: 200 });
+  }
+);
+
 export const userAll = http.get(
   `${import.meta.env.VITE_APP_API_BASE_URL}users`,
   () => {

--- a/src/mock/userpage.ts
+++ b/src/mock/userpage.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from 'msw';
 import mockUserpageProfileData from './mockUserpageProfileData.json';
 import mockUserpageAppliedProjectListData from './mockUserpageAppliedProjectListData.json';
 import mockUsers from './mockUsers.json';
+import mockAllUsers from './mockAllUser.json';
 
 export const userPageProfile = http.get(
   `${import.meta.env.VITE_APP_API_BASE_URL}user/:id`,
@@ -31,6 +32,6 @@ export const userAllPreview = http.get(
 export const userAll = http.get(
   `${import.meta.env.VITE_APP_API_BASE_URL}users`,
   () => {
-    return HttpResponse.json(mockUsers, { status: 200 });
+    return HttpResponse.json(mockAllUsers, { status: 200 });
   }
 );

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -1,5 +1,6 @@
 //model
 import { ApiCommonType, User } from './apiCommon';
+import { PositionTag, SkillTag } from './tags';
 
 export interface VerifyEmail {
   email: string;
@@ -28,13 +29,24 @@ export interface ApiOauth extends ApiCommonType {
   user: UserData;
 }
 
-export interface ApiGetAllUsers extends ApiCommonType {
+export interface ApiGetAllUsersPreview extends ApiCommonType {
   data: AllUserPreview[];
+}
+
+export interface ApiGetAllUsers extends ApiCommonType {
+  data: AllUser[];
 }
 
 export interface AllUserPreview {
   id: number;
   email: string;
   user: User;
+  userState: '접속 중' | '오프라인' | '정지';
   createdAt: string;
+}
+
+export interface AllUser extends AllUserPreview {
+  skill: SkillTag[];
+  position: PositionTag[];
+  reportedCount: number;
 }

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -29,10 +29,10 @@ export interface ApiOauth extends ApiCommonType {
 }
 
 export interface ApiGetAllUsers extends ApiCommonType {
-  data: AllUser[];
+  data: AllUserPreview[];
 }
 
-export interface AllUser {
+export interface AllUserPreview {
   id: number;
   email: string;
   user: User;

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -1,6 +1,18 @@
 import { PositionTag, SkillTag } from './tags';
 import { type ApiCommonType, type User } from './apiCommon';
 
+export enum UserState {
+  ONLINE = 'ONLINE',
+  OFFLINE = 'OFFLINE',
+  SUSPENDED = 'SUSPENDED',
+}
+
+export const USER_STATE_LABELS = {
+  [UserState.ONLINE]: '접속 중',
+  [UserState.OFFLINE]: '오프라인',
+  [UserState.SUSPENDED]: '정지',
+} as const;
+
 export interface VerifyEmail {
   email: string;
   code: string;
@@ -35,7 +47,7 @@ export interface AllUserPreview {
   id: number;
   email: string;
   user: User;
-  userState: '접속 중' | '오프라인' | '정지';
+  userState: UserState;
   createdAt: string;
 }
 

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -32,11 +32,6 @@ export interface ApiOauth extends ApiCommonType {
 export interface ApiGetAllUsersPreview extends ApiCommonType {
   data: AllUserPreview[];
 }
-
-export interface ApiGetAllUsers extends ApiCommonType {
-  data: AllUser[];
-}
-
 export interface AllUserPreview {
   id: number;
   email: string;
@@ -45,8 +40,17 @@ export interface AllUserPreview {
   createdAt: string;
 }
 
+export interface ApiGetAllUsers extends ApiCommonType {
+  data: AllUserList;
+}
+
 export interface AllUser extends AllUserPreview {
   skill: SkillTag[];
   position: PositionTag[];
   reportedCount: number;
+}
+
+export interface AllUserList {
+  allUsers: AllUser[];
+  totalPages: number;
 }

--- a/src/models/report.ts
+++ b/src/models/report.ts
@@ -13,9 +13,9 @@ export interface ApiAllReports extends ApiCommonType {
 
 export interface AllReports {
   id: number;
-  imposedCount: number;
+  reportedCount: number;
   category: string;
   user: User;
-  isImposed: boolean;
+  isDone: boolean;
   createdAt: string;
 }

--- a/src/models/search.ts
+++ b/src/models/search.ts
@@ -1,0 +1,4 @@
+export interface SearchType {
+  keyword: string;
+  page: number;
+}

--- a/src/pages/admin/adminAllUser/AdminAllUser.styled.ts
+++ b/src/pages/admin/adminAllUser/AdminAllUser.styled.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+export const Container = styled.div``;
+
+export const SearchBar = styled.div`
+  margin-top: 20px;
+`;
+
+export const ScrollArea = styled.div`
+  height: calc(100vh - 200px);
+  overflow-y: auto;
+  padding-bottom: 100px;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: #ccc;
+    border-radius: 4px;
+  }
+`;
+
+export const UserContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 10px;
+  padding: 20px;
+`;
+
+export const PageNumber = styled.div``;

--- a/src/pages/admin/adminAllUser/AdminAllUser.styled.ts
+++ b/src/pages/admin/adminAllUser/AdminAllUser.styled.ts
@@ -27,5 +27,3 @@ export const UserContainer = styled.div`
   gap: 10px;
   padding: 20px;
 `;
-
-export const PageNumber = styled.div``;

--- a/src/pages/admin/adminAllUser/AdminAllUser.tsx
+++ b/src/pages/admin/adminAllUser/AdminAllUser.tsx
@@ -28,7 +28,7 @@ const AdminAllUser = () => {
         <AdminTitle title='회원 전체 조회' />
 
         <S.SearchBar>
-          <SearchBar onGetKeyword={handleGetKeyword} />
+          <SearchBar onGetKeyword={handleGetKeyword} isNotice={false} />
         </S.SearchBar>
 
         <S.ScrollArea>

--- a/src/pages/admin/adminAllUser/AdminAllUser.tsx
+++ b/src/pages/admin/adminAllUser/AdminAllUser.tsx
@@ -10,7 +10,7 @@ import useSearchBar from '../../../hooks/admin/useSearchBar';
 import { ADMIN_MODAL_MESSAGE } from '../../../constants/admin/adminModal';
 
 const AdminAllUser = () => {
-  const { searchUnit, handleGetKeyword, handleChangePagination } =
+  const { searchUnit, value, handleGetKeyword, handleChangePagination } =
     useSearchBar();
   const { allUserData, isLoading, isFetching } = useGetAllUsers(searchUnit);
 
@@ -28,7 +28,11 @@ const AdminAllUser = () => {
         <AdminTitle title='회원 전체 조회' />
 
         <S.SearchBar>
-          <SearchBar onGetKeyword={handleGetKeyword} isNotice={false} />
+          <SearchBar
+            onGetKeyword={handleGetKeyword}
+            isNotice={false}
+            value={value}
+          />
         </S.SearchBar>
 
         <S.ScrollArea>

--- a/src/pages/admin/adminAllUser/AdminAllUser.tsx
+++ b/src/pages/admin/adminAllUser/AdminAllUser.tsx
@@ -1,3 +1,50 @@
-export default function AdminAllUser() {
-  return <div></div>;
-}
+import * as S from './AdminAllUser.styled';
+import AdminTitle from '../../../components/common/admin/title/AdminTitle';
+import { useGetAllUsers } from '../../../hooks/admin/useGetAllUsers';
+import LoadingSpinner from '../../../components/common/loadingSpinner/LoadingSpinner';
+import UserCard from '../../../components/admin/userCard/UserCard';
+import ScrollPreventor from '../../../components/common/modal/ScrollPreventor';
+import SearchBar from '../../../components/common/admin/searchBar/SearchBar';
+import Pagination from '../../../components/common/pagination/Pagination';
+import useSearchBar from '../../../hooks/admin/useSearchBar';
+
+const AdminAllUser = () => {
+  const { searchUnit, value, handleGetKeyword, handleChangePagination } =
+    useSearchBar();
+  const { allUserData, isLoading, isFetching } = useGetAllUsers(searchUnit);
+
+  if (isLoading || isFetching) {
+    return <LoadingSpinner />;
+  }
+
+  if (!allUserData || allUserData.allUsers.length === 0) {
+    return <S.Container>결과가 존재하지 않습니다.</S.Container>;
+  }
+
+  return (
+    <ScrollPreventor>
+      <S.Container>
+        <AdminTitle title='회원 전체 조회' />
+
+        <S.SearchBar>
+          <SearchBar onGetKeyword={handleGetKeyword} value={value} />
+        </S.SearchBar>
+
+        <S.ScrollArea>
+          <S.UserContainer>
+            {allUserData.allUsers?.map((userData) => (
+              <UserCard key={userData.id} userData={userData} />
+            ))}
+          </S.UserContainer>
+          <Pagination
+            page={searchUnit.page}
+            getLastPage={allUserData.totalPages}
+            onChangePagination={handleChangePagination}
+          />
+        </S.ScrollArea>
+      </S.Container>
+    </ScrollPreventor>
+  );
+};
+
+export default AdminAllUser;

--- a/src/pages/admin/adminAllUser/AdminAllUser.tsx
+++ b/src/pages/admin/adminAllUser/AdminAllUser.tsx
@@ -7,9 +7,10 @@ import ScrollPreventor from '../../../components/common/modal/ScrollPreventor';
 import SearchBar from '../../../components/common/admin/searchBar/SearchBar';
 import Pagination from '../../../components/common/pagination/Pagination';
 import useSearchBar from '../../../hooks/admin/useSearchBar';
+import { ADMIN_MODAL_MESSAGE } from '../../../constants/admin/adminModal';
 
 const AdminAllUser = () => {
-  const { searchUnit, value, handleGetKeyword, handleChangePagination } =
+  const { searchUnit, handleGetKeyword, handleChangePagination } =
     useSearchBar();
   const { allUserData, isLoading, isFetching } = useGetAllUsers(searchUnit);
 
@@ -18,7 +19,7 @@ const AdminAllUser = () => {
   }
 
   if (!allUserData || allUserData.allUsers.length === 0) {
-    return <S.Container>결과가 존재하지 않습니다.</S.Container>;
+    return <S.Container>{ADMIN_MODAL_MESSAGE.NO_RESULT}</S.Container>;
   }
 
   return (
@@ -27,7 +28,7 @@ const AdminAllUser = () => {
         <AdminTitle title='회원 전체 조회' />
 
         <S.SearchBar>
-          <SearchBar onGetKeyword={handleGetKeyword} value={value} />
+          <SearchBar onGetKeyword={handleGetKeyword} />
         </S.SearchBar>
 
         <S.ScrollArea>

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -10,7 +10,8 @@ export type ColorKey =
   | 'green'
   | 'navy'
   | 'lightnavy'
-  | 'warn';
+  | 'warn'
+  | 'blue';
 
 export type HeadingSize =
   | 'large'
@@ -78,6 +79,7 @@ export const defaultTheme: Theme = {
     navy: '#213555',
     lightnavy: '#92bbf0',
     warn: '#EC1E4F',
+    blue: '#2560E8',
   },
   heading: {
     large: { fontSize: '1.75rem', tabletFontSize: '1.5rem' },


### PR DESCRIPTION
### 구현내용

- API 미구현으로 mock 데이터로 대체
![image](https://github.com/user-attachments/assets/0a2b9ed8-8661-4463-b041-07199ebcea92)

### 연관이슈

close #324 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 관리자 페이지에서 전체 유저 목록을 검색 및 페이지네이션과 함께 확인할 수 있는 화면이 추가되었습니다.
  - 유저 카드 컴포넌트가 도입되어 유저의 상태, 이메일, 닉네임, 포지션, 스킬, 신고 횟수 등 상세 정보를 한눈에 볼 수 있습니다.
  - 검색바와 검색 결과, 페이지네이션 기능이 개선되었습니다.
  - 유저 프리뷰 데이터를 별도로 조회하는 기능과 관련 훅이 추가되었습니다.

- **버그 수정**
  - 유저 프리뷰 및 전체 유저 데이터의 표시 방식이 일관성 있게 개선되었습니다.

- **스타일**
  - 관리자 페이지 UI가 테마 색상 기반으로 개선되고, 스크롤 영역 및 그리드 레이아웃 등 시각적 요소가 향상되었습니다.
  - 상태 및 보고 현황 표시 색상이 하드코딩에서 테마 색상으로 변경되었습니다.

- **리팩터**
  - 유저 상태, 신고 관련 데이터 구조 및 명칭이 더 명확하게 변경되었습니다.
  - 신고 관련 용어가 'imposed'에서 'reported' 및 'done'으로 변경되었습니다.

- **문서화**
  - 검색, 유저, 신고 관련 타입 및 인터페이스가 추가 및 정비되었습니다.

- **테스트/목업**
  - 전체 유저 목록 및 프리뷰를 위한 목업 데이터와 핸들러가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->