### PR TITLE
관리자 문의답변 추가에 대한 마이페이지 알림 추가 수정( #issue 353 )

### DIFF
--- a/src/components/user/mypage/ContentTab.tsx
+++ b/src/components/user/mypage/ContentTab.tsx
@@ -57,7 +57,6 @@ export default function ContentTab({ filter, $justifyContent }: ContentProps) {
             to={filter.url}
             onClick={() => handleChangeId(filter.id as number)}
           >
-            {' '}
             <S.WrapperTitle $selected={filter?.id === filterId}>
               <S.FilterTitle>{filter.title}</S.FilterTitle>
             </S.WrapperTitle>

--- a/src/components/user/mypage/activityLog/inquiries/Inquiries.styled.ts
+++ b/src/components/user/mypage/activityLog/inquiries/Inquiries.styled.ts
@@ -21,7 +21,7 @@ export const InquiriesTableHeadContainer = styled.div`
 export const InquiriesTableHeadWrapper = styled.div`
   width: 100%;
   display: grid;
-  grid-template-columns: 8% 15% 65% 17%;
+  grid-template-columns: 8% 15% 65% 12%;
   font-size: 1.3rem;
   font-weight: 600;
   margin-bottom: 0.5rem;

--- a/src/components/user/mypage/activityLog/inquiries/Inquiries.styled.ts
+++ b/src/components/user/mypage/activityLog/inquiries/Inquiries.styled.ts
@@ -16,6 +16,7 @@ export const InquiriesTableHeadContainer = styled.div`
   padding-top: 1rem;
   top: 0;
   background: ${({ theme }) => theme.color.lightgrey};
+  z-index: 10000;
 `;
 
 export const InquiriesTableHeadWrapper = styled.div`
@@ -44,15 +45,15 @@ export const InquiriesTableHeaderState = styled.div`
   text-align: center;
 `;
 
-export const MyInquiriesWrapper = styled.div<{ $headHeight: number }>`
-  scroll-margin-top: ${({ $headHeight }) => $headHeight + 10}px;
-`;
-
 export const InquiriesWrapper = styled.div`
   margin-top: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+`;
+
+export const MyInquiriesWrapper = styled.div`
+  scroll-margin-top: 65px;
 `;
 
 export const WrapperNoContentAppliedProjects = styled(WrapperNoContent)``;

--- a/src/components/user/mypage/activityLog/inquiries/Inquiries.styled.ts
+++ b/src/components/user/mypage/activityLog/inquiries/Inquiries.styled.ts
@@ -44,6 +44,10 @@ export const InquiriesTableHeaderState = styled.div`
   text-align: center;
 `;
 
+export const MyInquiriesWrapper = styled.div<{ $headHeight: number }>`
+  scroll-margin-top: ${({ $headHeight }) => $headHeight + 10}px;
+`;
+
 export const InquiriesWrapper = styled.div`
   margin-top: 1rem;
   display: flex;

--- a/src/components/user/mypage/activityLog/inquiries/Inquiries.tsx
+++ b/src/components/user/mypage/activityLog/inquiries/Inquiries.tsx
@@ -6,7 +6,7 @@ import Spinner from '../../Spinner';
 import * as S from './Inquiries.styled';
 import Inquiry from './inquiry/Inquiry';
 import type { MyInquiries } from '../../../../../models/activityLog';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 
 export default function Inquiries() {
   const { userId } = useParams();
@@ -16,16 +16,13 @@ export default function Inquiries() {
     Number(userId),
     'inquiries'
   );
-  const headRef = useRef<HTMLDivElement>(null);
   const inquiriesRef = useRef<(HTMLDivElement | null)[]>([]);
-  const [headHeight, setHeadHeight] = useState<number>(0);
 
   useLayoutEffect(() => {
-    if (!id || !headRef?.current) return;
-    const height = headRef.current.offsetHeight;
-    setHeadHeight(height);
+    if (!id || !userActivityData) return;
     const idx = userActivityData?.findIndex((item) => item.id == id);
-    const targetRef = idx !== undefined ? inquiriesRef.current[idx] : null;
+    const targetRef =
+      idx !== undefined && idx >= 0 ? inquiriesRef.current[idx] : null;
     if (inquiriesRef?.current && targetRef) {
       targetRef.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
@@ -53,7 +50,7 @@ export default function Inquiries() {
   return (
     <S.container>
       <S.InquiriesContainer>
-        <S.InquiriesTableHeadContainer ref={headRef}>
+        <S.InquiriesTableHeadContainer>
           <S.InquiriesTableHeadWrapper>
             <S.InquiriesTableHeaderNo>No</S.InquiriesTableHeaderNo>
             <S.InquiriesTableHeaderCategory>
@@ -69,7 +66,6 @@ export default function Inquiries() {
             <S.MyInquiriesWrapper
               ref={(el) => (inquiriesRef.current[index] = el)}
               key={`${index}-${list.title}`}
-              $headHeight={headHeight}
             >
               <Inquiry list={list} no={myInquiriesData.length - index} />
             </S.MyInquiriesWrapper>

--- a/src/components/user/mypage/activityLog/inquiries/Inquiries.tsx
+++ b/src/components/user/mypage/activityLog/inquiries/Inquiries.tsx
@@ -25,11 +25,11 @@ export default function Inquiries() {
     const height = headRef.current.offsetHeight;
     setHeadHeight(height);
     const idx = userActivityData?.findIndex((item) => item.id == id);
-    const targetRef = typeof idx === 'number' ? inquiriesRef.current[idx] : '';
+    const targetRef = idx !== undefined ? inquiriesRef.current[idx] : null;
     if (inquiriesRef?.current && targetRef) {
       targetRef.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
-  }, [userActivityData, id, headHeight]);
+  }, [userActivityData, id]);
 
   if (isLoading) {
     return (

--- a/src/components/user/mypage/activityLog/inquiries/Inquiries.tsx
+++ b/src/components/user/mypage/activityLog/inquiries/Inquiries.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import useGetUserActivity from '../../../../../hooks/admin/useGetAllUserActivity';
 import ContentBorder from '../../../../common/contentBorder/ContentBorder';
 import NoContent from '../../../../common/noContent/NoContent';
@@ -6,13 +6,30 @@ import Spinner from '../../Spinner';
 import * as S from './Inquiries.styled';
 import Inquiry from './inquiry/Inquiry';
 import type { MyInquiries } from '../../../../../models/activityLog';
+import { useLayoutEffect, useRef, useState } from 'react';
 
 export default function Inquiries() {
   const { userId } = useParams();
+  const { state } = useLocation();
+  const { id } = state || {};
   const { userActivityData, isLoading } = useGetUserActivity(
     Number(userId),
     'inquiries'
   );
+  const headRef = useRef<HTMLDivElement>(null);
+  const inquiriesRef = useRef<(HTMLDivElement | null)[]>([]);
+  const [headHeight, setHeadHeight] = useState<number>(0);
+
+  useLayoutEffect(() => {
+    if (!id || !headRef?.current) return;
+    const height = headRef.current.offsetHeight;
+    setHeadHeight(height);
+    const idx = userActivityData?.findIndex((item) => item.id == id);
+    const targetRef = typeof idx === 'number' ? inquiriesRef.current[idx] : '';
+    if (inquiriesRef?.current && targetRef) {
+      targetRef.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [userActivityData, id, headHeight]);
 
   if (isLoading) {
     return (
@@ -36,7 +53,7 @@ export default function Inquiries() {
   return (
     <S.container>
       <S.InquiriesContainer>
-        <S.InquiriesTableHeadContainer>
+        <S.InquiriesTableHeadContainer ref={headRef}>
           <S.InquiriesTableHeadWrapper>
             <S.InquiriesTableHeaderNo>No</S.InquiriesTableHeaderNo>
             <S.InquiriesTableHeaderCategory>
@@ -49,11 +66,13 @@ export default function Inquiries() {
         </S.InquiriesTableHeadContainer>
         <S.InquiriesWrapper>
           {myInquiriesData.map((list, index) => (
-            <Inquiry
+            <S.MyInquiriesWrapper
+              ref={(el) => (inquiriesRef.current[index] = el)}
               key={`${index}-${list.title}`}
-              list={list}
-              no={myInquiriesData.length - index}
-            />
+              $headHeight={headHeight}
+            >
+              <Inquiry list={list} no={myInquiriesData.length - index} />
+            </S.MyInquiriesWrapper>
           ))}
         </S.InquiriesWrapper>
       </S.InquiriesContainer>

--- a/src/components/user/mypage/activityLog/inquiries/inquiry/Inquiry.styled.ts
+++ b/src/components/user/mypage/activityLog/inquiries/inquiry/Inquiry.styled.ts
@@ -9,7 +9,7 @@ export const InquiryTitleWrapper = styled.button`
   text-align: start;
   font-size: 1.1rem;
   display: grid;
-  grid-template-columns: 8% 15% 65% 17%;
+  grid-template-columns: 8% 15% 65% 12%;
   cursor: pointer;
 `;
 

--- a/src/components/user/mypage/activityLog/inquiries/inquiry/Inquiry.styled.ts
+++ b/src/components/user/mypage/activityLog/inquiries/inquiry/Inquiry.styled.ts
@@ -34,8 +34,8 @@ export const InquiryStateSpan = styled.span<{ $isCompletedAnswer: boolean }>`
     $isCompletedAnswer &&
     css`
       background: ${({ theme }) => theme.color.navy};
-      border-radius: ${({ theme }) => theme.borderRadius.small};
-      padding: 0.2rem;
+      border-radius: ${({ theme }) => theme.borderRadius.large};
+      padding: 0.2rem 0.5rem;
     `}
 `;
 

--- a/src/components/user/mypage/activityLog/inquiries/inquiry/Inquiry.tsx
+++ b/src/components/user/mypage/activityLog/inquiries/inquiry/Inquiry.tsx
@@ -1,9 +1,10 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { MyInquiries } from '../../../../../../models/activityLog';
 import * as S from './Inquiry.styled';
 import { My_INQUIRIES_MESSAGE } from '../../../../../../constants/user/customerService';
 import ContentBorder from '../../../../../common/contentBorder/ContentBorder';
 import { ChevronRightIcon } from '@heroicons/react/24/outline';
+import { useLocation } from 'react-router-dom';
 
 interface InquiryProps {
   list: MyInquiries;
@@ -16,26 +17,28 @@ interface IsImageOpen {
 }
 
 export default function Inquiry({ list, no }: InquiryProps) {
+  const { state } = useLocation();
+  const { id } = state || {};
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isImageOpen, setIsImageOpen] = useState<IsImageOpen>({
     isImageOpen: false,
     url: '',
   });
   const answer = list.answer || '';
-  const answerRef = useRef<HTMLTextAreaElement>(null);
+  const divRef = useRef<HTMLDivElement>(null);
 
-  const handleChangeAnswerRef = () => {
-    if (answerRef && answerRef.current) {
-      answerRef.current.style.height = 'auto';
-      answerRef.current.style.height = `${answerRef.current.scrollHeight}px`;
+  useEffect(() => {
+    if (list.id === id) {
+      setIsOpen(true);
     }
-  };
+  }, [list, id, setIsOpen]);
 
   return (
-    <S.Container>
+    <S.Container ref={divRef}>
       <S.InquiryTitleWrapper
         type='button'
         onClick={() => setIsOpen((prev) => !prev)}
+        data-id={list.id}
       >
         <S.InquiryNumber>{no}</S.InquiryNumber>
         <S.InquiryCategory>{`[${list.category}]`}</S.InquiryCategory>

--- a/src/components/user/mypage/activityLog/inquiries/inquiry/Inquiry.tsx
+++ b/src/components/user/mypage/activityLog/inquiries/inquiry/Inquiry.tsx
@@ -31,7 +31,7 @@ export default function Inquiry({ list, no }: InquiryProps) {
     if (list.id === id) {
       setIsOpen(true);
     }
-  }, [list, id, setIsOpen]);
+  }, [list.id, id]);
 
   return (
     <S.Container ref={divRef}>

--- a/src/components/user/mypage/notifications/all/All.tsx
+++ b/src/components/user/mypage/notifications/all/All.tsx
@@ -15,7 +15,6 @@ export default function All() {
   const { mutate: patchAlarm } = useAlarmPatch();
 
   const linkUrl = (id: number, filter: number) => {
-    // 문의, 신고 답변시 추후 수정
     if (filter === 1 || filter === 3) {
       return `${ROUTES.projectDetail}/${id}`;
     } else if (filter === 2) {

--- a/src/components/user/mypage/notifications/all/All.tsx
+++ b/src/components/user/mypage/notifications/all/All.tsx
@@ -13,8 +13,9 @@ export default function All() {
   const { filterId }: { filterId: number } = useOutletContext();
   const { mutate: deleteAlarm } = useAlarmDelete();
   const { mutate: patchAlarm } = useAlarmPatch();
+  console.log(alarmListData);
 
-  const linkUrl = (id: number, filter: number, replier = 0) => {
+  const linkUrl = (id: number, filter: number, replier: number = 0) => {
     // 문의, 신고 답변시 추후 수정
     if (filter === 1 || filter === 3) {
       if (replier === 3) {
@@ -25,7 +26,7 @@ export default function All() {
     } else if (filter === 2) {
       return `${ROUTES.manageProjectsRoot}/${id}`;
     } else if (filter === 4) {
-      return ``;
+      return `${ROUTES.mypage}/${ROUTES.myPageActivityLog}/${ROUTES.activityInquiries}`;
     } else {
       return `${ROUTES.mypage}/${ROUTES.myPageNotifications}`;
     }
@@ -62,6 +63,8 @@ export default function All() {
         {alarmListData
           .filter((list) => {
             if (filterId === 0) {
+              return true;
+            } else if (filterId === 3 && list.alarmFilterId === 4) {
               return true;
             } else if (list.alarmFilterId === filterId) {
               return true;

--- a/src/components/user/mypage/notifications/all/All.tsx
+++ b/src/components/user/mypage/notifications/all/All.tsx
@@ -13,16 +13,11 @@ export default function All() {
   const { filterId }: { filterId: number } = useOutletContext();
   const { mutate: deleteAlarm } = useAlarmDelete();
   const { mutate: patchAlarm } = useAlarmPatch();
-  console.log(alarmListData);
 
-  const linkUrl = (id: number, filter: number, replier: number = 0) => {
+  const linkUrl = (id: number, filter: number) => {
     // 문의, 신고 답변시 추후 수정
     if (filter === 1 || filter === 3) {
-      if (replier === 3) {
-        return `/${ROUTES.myPageActivityLog}/${ROUTES.activityInquiries}`;
-      } else {
-        return `${ROUTES.projectDetail}/${id}`;
-      }
+      return `${ROUTES.projectDetail}/${id}`;
     } else if (filter === 2) {
       return `${ROUTES.manageProjectsRoot}/${id}`;
     } else if (filter === 4) {
@@ -49,7 +44,7 @@ export default function All() {
     return false;
   }).length;
 
-  if (!alarmListData || alarmListData.length === 0 || filterLength === 0) {
+  if (!alarmListData?.length || filterLength === 0) {
     return (
       <S.WrapperNoContent data-type='noContent'>
         <NoContent type='notification' />
@@ -76,7 +71,7 @@ export default function All() {
               {/* 신고하기 알림 구별 */}
               {list.alarmFilterId !== 5 ? (
                 <Link
-                  to={linkUrl(list.routingId, list.alarmFilterId, list.replier)}
+                  to={linkUrl(list.routingId, list.alarmFilterId)}
                   onClick={() => patchAlarm(list.id)}
                 >
                   <S.SpanNotification

--- a/src/components/user/mypage/notifications/all/All.tsx
+++ b/src/components/user/mypage/notifications/all/All.tsx
@@ -6,6 +6,7 @@ import { useAlarmDelete } from '../../../../../hooks/user/useAlarmDelete';
 import { useAlarmPatch } from '../../../../../hooks/user/useAlarmPatch';
 import useAlarmList from '../../../../../hooks/user/useAlarmList';
 import NoContent from '../../../../common/noContent/NoContent';
+import { ROUTES } from '../../../../../constants/routes';
 
 export default function All() {
   const { alarmListData, isLoading } = useAlarmList();
@@ -17,14 +18,16 @@ export default function All() {
     // 문의, 신고 답변시 추후 수정
     if (filter === 1 || filter === 3) {
       if (replier === 3) {
-        return `/activity-log/inquiries`;
+        return `/${ROUTES.myPageActivityLog}/${ROUTES.activityInquiries}`;
       } else {
-        return `/project-detail/${id}`;
+        return `${ROUTES.projectDetail}/${id}`;
       }
     } else if (filter === 2) {
-      return `/manage/${id}`;
+      return `${ROUTES.manageProjectsRoot}/${id}`;
+    } else if (filter === 4) {
+      return ``;
     } else {
-      return `/mypage/notification`;
+      return `${ROUTES.mypage}/${ROUTES.myPageNotifications}`;
     }
   };
 

--- a/src/components/user/mypage/notifications/all/All.tsx
+++ b/src/components/user/mypage/notifications/all/All.tsx
@@ -71,6 +71,7 @@ export default function All() {
               {list.alarmFilterId !== 5 ? (
                 <Link
                   to={linkUrl(list.routingId, list.alarmFilterId)}
+                  state={list.alarmFilterId === 4 && { id: list.routingId }}
                   onClick={() => patchAlarm(list.id)}
                 >
                   <S.SpanNotification

--- a/src/constants/user/myPageFilter.ts
+++ b/src/constants/user/myPageFilter.ts
@@ -6,19 +6,19 @@ export const NOTIFICATION_FILTER = [
     title: '지원한 프로젝트',
     url: ROUTES.notificationsAppliedProjects,
     id: 1,
-    linkUrl: `/project-detail`,
+    linkUrl: ROUTES.projectDetail,
   },
   {
     title: '지원자 확인',
     url: ROUTES.notificationsCheckedApplicants,
     id: 2,
-    linkUrl: `/project-detail`,
+    linkUrl: ROUTES.projectDetail,
   },
   {
     title: '댓글&답변',
     url: ROUTES.comments,
     id: 3,
-    linkUrl: `/project-detail`,
+    linkUrl: ROUTES.projectDetail,
   },
 ] as const;
 


### PR DESCRIPTION
### 구현내용

관리자 문의 답변 추가에 대해 마이페이지 알림 필터 추가
알림 클릭시 라우터 이동
내 문의글 이동시 답변완료된 알림의 문의를 보여주고 스크롤 이동

### 연관이슈

close #353 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 문의 내역에서 특정 문의로 바로 스크롤되는 기능이 추가되었습니다.

* **버그 수정**
  * 문의 내역 및 알림 목록의 필터 및 링크 이동 로직이 개선되었습니다.

* **스타일**
  * 문의 내역 테이블과 상태 표시, 버튼 등의 레이아웃 및 시각적 요소가 일부 조정되었습니다.

* **리팩터**
  * 라우트 경로 관리가 상수로 통합되어 일관성이 향상되었습니다.
  * 불필요한 공백 및 미사용 코드가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->